### PR TITLE
구글 로그인 기능 개선

### DIFF
--- a/packages/backend/src/auth/google/googleAuth.controller.ts
+++ b/packages/backend/src/auth/google/googleAuth.controller.ts
@@ -21,6 +21,8 @@ export class GoogleAuthController {
   @Get('/redirect')
   @UseGuards(GoogleAuthGuard)
   async handleRedirect(@Res() response: Response) {
-    response.redirect('/');
+    const redirectUrl =
+      process.env.NODE_ENV === 'production' ? '/' : 'http://localhost:5173';
+    response.redirect(redirectUrl);
   }
 }

--- a/packages/backend/src/user/domain/user.entity.ts
+++ b/packages/backend/src/user/domain/user.entity.ts
@@ -35,7 +35,7 @@ export class User {
   @Column({ length: 10, default: OauthType.LOCAL })
   type: OauthType = OauthType.LOCAL;
 
-  @Column('decimal', { name: 'oauth_id' })
+  @Column('varchar', { name: 'oauth_id', length: 255 })
   oauthId: string;
 
   @Column({ name: 'is_light', default: true })

--- a/packages/frontend/src/pages/login/Login.tsx
+++ b/packages/frontend/src/pages/login/Login.tsx
@@ -4,7 +4,9 @@ import { useGetTestLogin } from '@/apis/queries/auth/useGetTestLogin';
 import Google from '@/assets/google.svg?react';
 import { Button } from '@/components/ui/button';
 
-const GOOGLE_LOGIN = '/api/auth/google/login';
+const BACKEND_URL = import.meta.env.VITE_BASE_URL;
+const GOOGLE_LOGIN = `${BACKEND_URL}/api/auth/google/login`;
+
 export const Login = () => {
   const queryClient = useQueryClient();
   const { refetch, isSuccess } = useGetTestLogin({
@@ -16,6 +18,10 @@ export const Login = () => {
     queryClient.invalidateQueries({ queryKey: ['loginStatus'] });
   }
 
+  const handleGoogleLogin = () => {
+    window.location.href = GOOGLE_LOGIN;
+  };
+
   return (
     <div className="flex h-[calc(100vh-8rem)] flex-col items-center justify-center">
       <main className="relative flex flex-col gap-36 rounded-lg bg-gradient-to-br from-[#ffe259] to-[#ffa751] p-16 py-24 shadow-sm dark:from-[#e26262] dark:to-[#f3d55d]">
@@ -25,12 +31,13 @@ export const Login = () => {
           <p className="display-medium20">주춤주춤과 함께해요!</p>
         </section>
         <section className="relative z-10 flex flex-col gap-4">
-          <Link to={GOOGLE_LOGIN} className="w-72" reloadDocument>
-            <Button className="flex h-10 w-full items-center justify-center gap-4 px-10 dark:bg-black">
-              <Google />
-              <span>구글 로그인</span>
-            </Button>
-          </Link>
+          <Button
+            onClick={handleGoogleLogin}
+            className="flex h-10 w-72 items-center justify-center gap-4 px-10 dark:bg-black"
+          >
+            <Google />
+            <span>구글 로그인</span>
+          </Button>
           <Link to="/" reloadDocument>
             <Button
               onClick={() => refetch()}


### PR DESCRIPTION
## 리팩토링 개요

- closes #2

## 리팩토링 세부 내역

- 로컬 환경에서 프론트 서버와 백엔드 서버를 별도로 실행하는 경우 구글 로그인이 정상적으로 동작하지 않는 문제가 발생
- 로컬 개발 환경에서도 제대로 동작할 수 있게 redirection 경로 수정
- 구글 oauth_id 의 길이가 decimal type의 범위를 벗어나는 경우가 발생하여 제대로 로그인이 안되는 현상 발생
- users 테이블의 oauth_id 칼럼의 타입을 varchar(255)로 변경

### 리팩토링 전

- react-router 의 Link 컴포넌트를 사용하기 때문에 백엔드 서버에 요청이 가지 않음

![image](https://github.com/user-attachments/assets/f8ac7dbc-bb44-4f49-8918-c6d16657635d)

- oauth_id의 out of range 에러

![oauth_id out of range](https://github.com/user-attachments/assets/10b42229-20bd-45cb-a80f-ea8595ec5085)


### 리팩토링 후

- 정상적인 redirection

![image](https://github.com/user-attachments/assets/bb358f15-a743-4a78-a7c1-404ecdade6e5)

