### PR TITLE
배포 환경에서 웹 소캣 연결 실패 문제 해결

### DIFF
--- a/cz-config.js
+++ b/cz-config.js
@@ -23,6 +23,6 @@ module.exports = {
 
   allowCustomScopes: false,
   allowBreakingChanges: ['feat', 'fix'],
-  skipQuestions: ['body', 'scope'],
+  skipQuestions: ['scope'],
   subjectLimit: 100,
 };

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -16,6 +16,7 @@ const setCors = (app: INestApplication) => {
       'http://localhost:3000',
       'https://juchum.info',
       'http://localhost:5173',
+      'http://juchumjuchum.site',
     ],
     methods: '*',
     allowedHeaders: [

--- a/packages/frontend/src/sockets/config.ts
+++ b/packages/frontend/src/sockets/config.ts
@@ -1,7 +1,6 @@
 import { io } from 'socket.io-client';
 
-// const URL = 'wss://juchum.info';
-const URL = 'ws://localhost:3000';
+const URL = import.meta.env.VITE_WS_URL;
 
 export interface SocketChatType {
   stockId: string;


### PR DESCRIPTION
- closes #12 

## ✅ 작업 내용 1

### 문제 상황
- 로컬 환경에서는 잘 동작하던 websocket이 배포 환경에서는 실패하는 문제

### 문제 원인
- 현재 웹 소캣 URL이 하드코딩되어 있다
- `frontend:latest` 도커 이미지에서 사용중이던 `nginx-frontend.conf` 파일에서 /socket.io 경로에 대한 리버스 프록시 설정이 없다

### 문제 해결
- 프론트엔드의 `.env` 파일 수정
  - [로컬 환경]
    ```
    VITE_BASE_URL=http://localhost:3000
    VITE_WS_URL=ws://localhost:3000
    ```
  - [배포 환경]
    ```
    VITE_BASE_URL=http://juchumjuchum.site
    VITE_WS_URL=ws://juchumjuchum.site
    ```

- `nginx-frontend.conf` 파일에 /socket.io 경로에 대한 설정을 추가

    ```
    # 웹 소캣 경로 추가
    location /socket.io {
      proxy_pass         http://nest-api-server/socket.io;
      proxy_http_version 1.1;
      proxy_set_header Upgrade $http_upgrade;
      proxy_set_header Connection 'upgrade';
      proxy_set_header Host $host;
    }
    ```

### [개발 일지](https://github.com/boostcampwm-2024/refactor-web40-juchumjuchum/wiki/%EB%B0%B0%ED%8F%AC-%ED%99%98%EA%B2%BD%EC%97%90%EC%84%9C-%EC%9B%B9-%EC%86%8C%EC%BA%A3-%EC%97%B0%EA%B2%B0-%EC%8B%A4%ED%8C%A8-%EB%AC%B8%EC%A0%9C-%ED%95%B4%EA%B2%B0)


## ✅ 작업 내용 2

### commitizen 설정 파일 변경

- 현재 cz-config.js 에서 skipQuestions 에 'body'가 포함되어 있어 커밋 메시지에 body를 추가할 수 없는 문제가 있었습니다
- 해당 부분을 삭제하여 `git cz` 명령을 통해 커밋 메시지를 작성할 때 body도 작성할 수 있도록 했습니다.



## 📸 스크린샷(FE만)

## 📌 이슈 사항

## 🟢 완료 조건

## ✍ 궁금한 점

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
