### PR TITLE
Github Actions를 이용한 CI/CD 구축

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -1,0 +1,73 @@
+name: Deploy Dev in Monorepo
+
+on:
+  push:
+    branches:
+      - dev
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+
+    services:
+      docker:
+        image: docker:20.10.7
+        options: --privileged
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Cache Yarn dependencies
+        uses: actions/cache@v3
+        with:
+          path: |
+            **/node_modules
+            ~/.yarn-cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build backend and frontend
+        run: |
+          yarn workspace backend build
+          yarn workspace frontend build
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Build and push Docker images
+        run: |
+          # 백엔드 이미지 빌드 및 푸시
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/backend:latest -f packages/backend/Dockerfile .
+          docker push ${{ secrets.DOCKER_USERNAME }}/backend:latest
+
+          # 프론트엔드 이미지 빌드 및 푸시
+          docker build -t ${{ secrets.DOCKER_USERNAME }}/frontend:latest -f packages/frontend/Dockerfile .
+          docker push ${{ secrets.DOCKER_USERNAME }}/frontend:latest
+
+      - name: Deploy to server
+        uses: appleboy/ssh-action@v1.1.0
+        with:
+          host: ${{ secrets.SERVER_HOST }}
+          username: ${{ secrets.SERVER_USER }}
+          key: ${{ secrets.SERVER_SSH_KEY}}
+          password: ${{ secrets.SERVER_PASSWORD }}
+          port: ${{ secrets.SERVER_PORT }}
+          script: |
+            docker pull ${{ secrets.DOCKER_USERNAME }}/frontend:latest
+            docker pull ${{ secrets.DOCKER_USERNAME }}/backend:latest
+            docker compose down 
+            docker compose up -d

--- a/cz-config.js
+++ b/cz-config.js
@@ -23,6 +23,6 @@ module.exports = {
 
   allowCustomScopes: false,
   allowBreakingChanges: ['feat', 'fix'],
-  skipQuestions: ['body', 'scope'],
+  skipQuestions: ['scope'],
   subjectLimit: 100,
 };

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -16,6 +16,7 @@ const setCors = (app: INestApplication) => {
       'http://localhost:3000',
       'https://juchum.info',
       'http://localhost:5173',
+      'http://juchumjuchum.site',
     ],
     methods: '*',
     allowedHeaders: [

--- a/packages/frontend/src/sockets/config.ts
+++ b/packages/frontend/src/sockets/config.ts
@@ -1,7 +1,6 @@
 import { io } from 'socket.io-client';
 
-// const URL = 'wss://juchum.info';
-const URL = 'ws://localhost:3000';
+const URL = import.meta.env.VITE_WS_URL;
 
 export interface SocketChatType {
   stockId: string;


### PR DESCRIPTION
- close #14 

## ✅ 작업 내용

### 시스템 아키텍처

<img src="https://github.com/user-attachments/assets/7b999a37-f9e5-4e2f-8767-e7c7bfcb45d0" width=900>

### CI/CD 프로세스

- `dev` 브랜치에 push 이벤트가 발생하면
- github에서 ubuntu 서버를 실행시키고
- docker in docker 컨테이너를 설치
- 소스코드를 가져오고, yarn 설정 캐싱
- 패키지 의존성을 설치하고, 백엔드와 프론트엔드 코드 빌드
- Dokcer hub에 로그인하고, Dockefile들을 기반으로 백엔드와 프론트엔드 docker image 빌드 및 푸시
- NCP 서버 인스턴스에 접속 및 docker compose 실행

### [개발 일지](https://github.com/boostcampwm-2024/refactor-web40-juchumjuchum/wiki/Github-Actions%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%9C-CI-CD-%EA%B5%AC%EC%B6%95)

## 📸 스크린샷(FE만)

## 📌 이슈 사항

## 🟢 완료 조건

## ✍ 궁금한 점

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
