### PR TITLE
stock service test 개선

### DIFF
--- a/packages/backend/src/stock/stock.service.spec.ts
+++ b/packages/backend/src/stock/stock.service.spec.ts
@@ -19,207 +19,259 @@ import {
 } from './strategy/StockSortStrategy';
 
 describe('StockService 테스트', () => {
-  const stockId = '005930';
-  const userId = 1;
-  const result = [
-    {
-      id: '005930',
-      name: '삼성전자',
-      currentPrice: '100000.0',
-      changeRate: '2.5',
-      volume: '500000',
-      marketCap: '500000000000.00',
-    },
-    {
-      id: 'A051910',
-      name: 'LG화학',
-      currentPrice: '75000.0',
-      changeRate: '-1.2',
-      volume: '300000',
-      marketCap: '20000000000.00',
-    },
-  ];
-  let logger: Logger;
+  // mocked classes
+  let mockLogger: Logger;
   let mockDataSource: DataSource;
   let mockManager: EntityManager;
+  let mockQueryBuilder: SelectQueryBuilder<Stock>;
+  let mockRepository: Repository<Stock>;
+  let mockViewsSortStrategy: ViewsSortStrategy;
+  let mockGainersSortStrategy: GainersSortStrategy;
+  let mockLosersSortStrategy: LosersSortStrategy;
+
+  // test target
   let stockService: StockService;
-  let queryBuilderMock: SelectQueryBuilder<Stock>;
-  let repositoryMock: Repository<Stock>;
-  let viewsSortStrategy: ViewsSortStrategy;
-  let gainersSortStrategy: GainersSortStrategy;
-  let losersSortStrategy: LosersSortStrategy;
 
   beforeEach(() => {
     mockDataSource = mock(DataSource);
-    logger = mock(Logger);
     mockManager = mock(EntityManager);
-    queryBuilderMock = mock(SelectQueryBuilder);
-    viewsSortStrategy = mock(ViewsSortStrategy);
-    gainersSortStrategy = mock(GainersSortStrategy);
-    losersSortStrategy = mock(LosersSortStrategy);
+    mockQueryBuilder = mock(SelectQueryBuilder);
+    mockRepository = mock(Repository);
+
+    mockLogger = mock(Logger);
+    mockViewsSortStrategy = mock(ViewsSortStrategy);
+    mockGainersSortStrategy = mock(GainersSortStrategy);
+    mockLosersSortStrategy = mock(LosersSortStrategy);
+
     stockService = new StockService(
       instance(mockDataSource),
-      instance(logger),
-      instance(viewsSortStrategy),
-      instance(gainersSortStrategy),
-      instance(losersSortStrategy),
+      instance(mockLogger),
+      instance(mockViewsSortStrategy),
+      instance(mockGainersSortStrategy),
+      instance(mockLosersSortStrategy),
     );
-    repositoryMock = mock(Repository);
+
+    // stock service 내부에서 사용하는 typeorm 메서드 mocking
     when(mockDataSource.transaction(anything())).thenCall(async (callback) => {
       return await callback(instance(mockManager));
     });
-    when(queryBuilderMock.leftJoin(anything(), anything(), anything()))
-      .thenReturn(instance(queryBuilderMock))
-      .thenReturn(instance(queryBuilderMock));
-    when(queryBuilderMock.select(anything())).thenReturn(
-      instance(queryBuilderMock),
+    when(mockQueryBuilder.leftJoin(anything(), anything(), anything()))
+      .thenReturn(instance(mockQueryBuilder))
+      .thenReturn(instance(mockQueryBuilder));
+    when(mockQueryBuilder.select(anything())).thenReturn(
+      instance(mockQueryBuilder),
     );
-    when(queryBuilderMock.orderBy(anything(), anything())).thenReturn(
-      instance(queryBuilderMock),
+    when(mockQueryBuilder.orderBy(anything(), anything())).thenReturn(
+      instance(mockQueryBuilder),
     );
-    when(queryBuilderMock.limit(anything())).thenReturn(
-      instance(queryBuilderMock),
+    when(mockQueryBuilder.limit(anything())).thenReturn(
+      instance(mockQueryBuilder),
     );
-    when(repositoryMock.createQueryBuilder(anyString())).thenReturn(
-      instance(queryBuilderMock),
+    when(mockRepository.createQueryBuilder(anyString())).thenReturn(
+      instance(mockQueryBuilder),
     );
     when(mockDataSource.getRepository(anything())).thenReturn(
-      instance(repositoryMock),
+      instance(mockRepository),
     );
-  });
-
-  test('주식의 조회수를 증가시킨다.', async () => {
-    when(mockManager.exists(Stock, anything())).thenResolve(true);
-
-    await stockService.increaseView(stockId);
-
-    verify(mockManager.exists(Stock, anything())).once();
-    verify(mockManager.increment(Stock, anything(), 'views', 1)).once();
-  });
-
-  test('존재하지 않는 주식의 조회수를 증가시키려 하면 예외가 발생한다.', async () => {
-    when(mockManager.exists(Stock, anything())).thenResolve(false);
-
-    await expect(() => stockService.increaseView('1')).rejects.toThrow(
-      'stock not found',
-    );
-  });
-
-  test('유저 주식을 추가한다.', async () => {
-    when(mockManager.exists(Stock, anything())).thenResolve(true);
-    when(mockManager.exists(UserStock, anything())).thenResolve(false);
-
-    await stockService.createUserStock(userId, stockId);
-
-    verify(mockManager.exists(Stock, anything())).times(1);
-    verify(mockManager.exists(UserStock, anything())).times(1);
-    verify(mockManager.insert(UserStock, anything())).once();
-  });
-
-  test('유저 주식을 추가할 때 존재하지 않는 주식이면 예외가 발생한다.', async () => {
-    when(mockManager.exists(Stock, anything())).thenResolve(false);
-
-    await expect(() =>
-      stockService.createUserStock(userId, 'A'),
-    ).rejects.toThrow('not exists stock');
-  });
-
-  test('유저 주식을 추가할 때 이미 존재하는 유저 주식이면 예외가 발생한다.', async () => {
-    when(mockManager.exists(Stock, anything())).thenResolve(true);
-    when(mockManager.exists(UserStock, anything())).thenResolve(true);
-
-    await expect(async () =>
-      stockService.createUserStock(userId, stockId),
-    ).rejects.toThrow('user stock already exists');
-  });
-
-  test('유저 주식을 삭제한다.', async () => {
-    when(mockManager.findOne(UserStock, anything())).thenResolve({
-      id: 1,
-      user: { id: userId } as User,
-      stock: { id: stockId } as Stock,
-      date: {
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    });
-
-    await stockService.deleteUserStock(userId, stockId);
-
-    verify(mockManager.findOne(UserStock, anything())).once();
-    verify(mockManager.delete(UserStock, anything())).once();
-  });
-
-  test('유저 주식을 삭제 시 존재하지 않는 유저 주식이면 예외가 발생한다.', async () => {
-    when(mockManager.findOne(UserStock, anything())).thenResolve(null);
-
-    await expect(() =>
-      stockService.deleteUserStock(userId, '13'),
-    ).rejects.toThrow('user stock not found');
-  });
-
-  test('유저 주식을 삭제 시 주인이 아닐 때 예외가 발생한다.', async () => {
-    const notOwnerUserId = 2;
-    when(mockManager.findOne(UserStock, anything())).thenResolve({
-      id: 1,
-      user: { id: userId } as User,
-      stock: { id: stockId } as Stock,
-      date: {
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    });
-
-    await expect(() =>
-      stockService.deleteUserStock(notOwnerUserId, stockId),
-    ).rejects.toThrow('you are not owner of user stock');
-  });
-
-  test('소유 주식인지 확인한다.', async () => {
-    when(mockManager.exists(UserStock, anything())).thenResolve(true);
-    const result = await stockService.isUserStockOwner(stockId, userId);
-
-    expect(result).toBe(true);
-  });
-
-  test('인증된 유저가 아니면 소유 주식은 항상 false를 반환한다.', async () => {
-    const result = await stockService.isUserStockOwner(stockId);
-
-    expect(result).toBe(false);
-  });
-
-  test('주식 조회수 기준 상위 데이터를 반환한다.', async () => {
-    const limit = 5;
-
-    when(queryBuilderMock.getRawMany()).thenResolve(result);
-
-    const queryResult = await stockService.getTopStocksByViews(limit);
-
-    expect(queryResult).toStrictEqual(
-      plainToInstance(StocksResponse, queryResult),
-    );
-    verify(queryBuilderMock.getRawMany()).once();
-  });
-
-  test('주식 상승률 기준 상위 데이터를 반환한다.', async () => {
-    const limit = 20;
     when(
-      queryBuilderMock.innerJoinAndSelect(anyString(), anyString()),
-    ).thenReturn(instance(queryBuilderMock));
-    when(queryBuilderMock.where(anyString(), anything())).thenReturn(
-      instance(queryBuilderMock),
+      mockQueryBuilder.innerJoinAndSelect(anyString(), anyString()),
+    ).thenReturn(instance(mockQueryBuilder));
+    when(mockQueryBuilder.where(anyString(), anything())).thenReturn(
+      instance(mockQueryBuilder),
     );
-    when(queryBuilderMock.getRawMany()).thenResolve(result);
-    const queryResult = await stockService.getTopStocksByGainers(limit);
-
-    verify(queryBuilderMock.getRawMany()).once();
-
-    expect(queryResult).toEqual(new StockRankResponses(result));
   });
 
-  test('인증된 유저가 아니면 소유 주식은 항상 false를 반환한다.', async () => {
-    const result = await stockService.isUserStockOwner(stockId);
+  describe('주식 조회수', () => {
+    test('주식의 조회수를 증가시킨다.', async () => {
+      // given
+      const stockId = '005930';
+      when(mockManager.exists(Stock, anything())).thenResolve(true);
 
-    expect(result).toBe(false);
+      // when
+      await stockService.increaseView(stockId);
+
+      // then
+      verify(mockManager.exists(Stock, anything())).once();
+      verify(mockManager.increment(Stock, anything(), 'views', 1)).once();
+    });
+
+    test('존재하지 않는 주식의 조회수를 증가시키려 하면 예외가 발생한다.', async () => {
+      // given
+      when(mockManager.exists(Stock, anything())).thenResolve(false);
+
+      // when & then
+      await expect(() => stockService.increaseView('1')).rejects.toThrow(
+        'stock not found',
+      );
+    });
+  });
+
+  describe('유저 주식 관리', () => {
+    test('유저 주식을 추가한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      when(mockManager.exists(Stock, anything())).thenResolve(true);
+      when(mockManager.exists(UserStock, anything())).thenResolve(false);
+
+      // when
+      await stockService.createUserStock(userId, stockId);
+
+      // then
+      verify(mockManager.exists(Stock, anything())).times(1);
+      verify(mockManager.exists(UserStock, anything())).times(1);
+      verify(mockManager.insert(UserStock, anything())).once();
+    });
+
+    test('유저 주식을 추가할 때 존재하지 않는 주식이면 예외가 발생한다.', async () => {
+      // given
+      const userId = 1;
+      when(mockManager.exists(Stock, anything())).thenResolve(false);
+
+      // when & then
+      await expect(() =>
+        stockService.createUserStock(userId, 'A'),
+      ).rejects.toThrow('not exists stock');
+    });
+
+    test('유저 주식을 추가할 때 이미 존재하는 유저 주식이면 예외가 발생한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      when(mockManager.exists(Stock, anything())).thenResolve(true);
+      when(mockManager.exists(UserStock, anything())).thenResolve(true);
+
+      // when & then
+      await expect(async () =>
+        stockService.createUserStock(userId, stockId),
+      ).rejects.toThrow('user stock already exists');
+    });
+
+    test('유저 주식을 삭제한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      when(mockManager.findOne(UserStock, anything())).thenResolve({
+        id: 1,
+        user: { id: userId } as User,
+        stock: { id: stockId } as Stock,
+        date: {
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      // when
+      await stockService.deleteUserStock(userId, stockId);
+
+      // then
+      verify(mockManager.findOne(UserStock, anything())).once();
+      verify(mockManager.delete(UserStock, anything())).once();
+    });
+
+    test('유저 주식을 삭제 시 존재하지 않는 유저 주식이면 예외가 발생한다.', async () => {
+      // given
+      const userId = 1;
+      when(mockManager.findOne(UserStock, anything())).thenResolve(null);
+
+      // when & then
+      await expect(() =>
+        stockService.deleteUserStock(userId, '13'),
+      ).rejects.toThrow('user stock not found');
+    });
+
+    test('유저 주식을 삭제 시 주인이 아닐 때 예외가 발생한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      const notOwnerUserId = 2;
+      when(mockManager.findOne(UserStock, anything())).thenResolve({
+        id: 1,
+        user: { id: userId } as User,
+        stock: { id: stockId } as Stock,
+        date: {
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      // when & then
+      await expect(() =>
+        stockService.deleteUserStock(notOwnerUserId, stockId),
+      ).rejects.toThrow('you are not owner of user stock');
+    });
+
+    test('소유 주식인지 확인한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      when(mockManager.exists(UserStock, anything())).thenResolve(true);
+
+      // when
+      const result = await stockService.isUserStockOwner(stockId, userId);
+
+      // then
+      expect(result).toBe(true);
+    });
+
+    test('인증된 유저가 아니면 소유 주식은 항상 false를 반환한다.', async () => {
+      // given
+      const stockId = '005930';
+      const userId = undefined;
+
+      // when
+      const result = await stockService.isUserStockOwner(stockId, userId);
+
+      // then
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('주식 검색', () => {
+    const stockList = [
+      {
+        id: '005930',
+        name: '삼성전자',
+        currentPrice: '100000.0',
+        changeRate: '2.5',
+        volume: '500000',
+        marketCap: '500000000000.00',
+      },
+      {
+        id: 'A051910',
+        name: 'LG화학',
+        currentPrice: '75000.0',
+        changeRate: '-1.2',
+        volume: '300000',
+        marketCap: '20000000000.00',
+      },
+    ];
+
+    test('주식 조회수 기준 상위 데이터를 반환한다.', async () => {
+      //given
+      const limit = 5;
+      when(mockQueryBuilder.getRawMany()).thenResolve(stockList);
+
+      // when
+      const queryResult = await stockService.getTopStocksByViews(limit);
+
+      // then
+      expect(queryResult).toStrictEqual(
+        plainToInstance(StocksResponse, queryResult),
+      );
+    });
+
+    test('주식 상승률 기준 상위 데이터를 반환한다.', async () => {
+      // given
+      const limit = 20;
+      when(mockQueryBuilder.getRawMany()).thenResolve(stockList);
+
+      // when
+      const queryResult = await stockService.getTopStocksByGainers(limit);
+
+      // then
+      verify(mockQueryBuilder.getRawMany()).once();
+      expect(queryResult).toEqual(new StockRankResponses(stockList));
+    });
   });
 });

--- a/packages/backend/src/stock/stock.service.spec.ts
+++ b/packages/backend/src/stock/stock.service.spec.ts
@@ -12,6 +12,11 @@ import { StockService } from './stock.service';
 import { UserStock } from '@/stock/domain/userStock.entity';
 import { StockRankResponses, StocksResponse } from '@/stock/dto/stock.response';
 import { User } from '@/user/domain/user.entity';
+import {
+  GainersSortStrategy,
+  LosersSortStrategy,
+  ViewsSortStrategy,
+} from './strategy/StockSortStrategy';
 
 describe('StockService 테스트', () => {
   const stockId = '005930';
@@ -40,13 +45,25 @@ describe('StockService 테스트', () => {
   let stockService: StockService;
   let queryBuilderMock: SelectQueryBuilder<Stock>;
   let repositoryMock: Repository<Stock>;
+  let viewsSortStrategy: ViewsSortStrategy;
+  let gainersSortStrategy: GainersSortStrategy;
+  let losersSortStrategy: LosersSortStrategy;
 
   beforeEach(() => {
     mockDataSource = mock(DataSource);
     logger = mock(Logger);
     mockManager = mock(EntityManager);
     queryBuilderMock = mock(SelectQueryBuilder);
-    stockService = new StockService(instance(mockDataSource), logger);
+    viewsSortStrategy = mock(ViewsSortStrategy);
+    gainersSortStrategy = mock(GainersSortStrategy);
+    losersSortStrategy = mock(LosersSortStrategy);
+    stockService = new StockService(
+      instance(mockDataSource),
+      instance(logger),
+      instance(viewsSortStrategy),
+      instance(gainersSortStrategy),
+      instance(losersSortStrategy),
+    );
     repositoryMock = mock(Repository);
     when(mockDataSource.transaction(anything())).thenCall(async (callback) => {
       return await callback(instance(mockManager));


### PR DESCRIPTION
close #23 

## ✅ 작업 내용

### Before
- 기존 stock.service.spec.ts 의 경우 given으로 주어지는 데이터 값에 대한 정보가 맨 위에 작성되어 있어 각 테스트마다 확인하기 어려웠습니다.
- 또한, given/when/then의 논리적 구조가 명확히 나뉘어지지 않은 부분이 있었고, ts-mockito 라이브러리의 when() 메서드를 사용하면서 더욱 헷갈리는 부분이 있었습니다.

```ts
test('주식 상승률 기준 상위 데이터를 반환한다.', async () => {
    const limit = 20;
    when(
      queryBuilderMock.innerJoinAndSelect(anyString(), anyString()),
    ).thenReturn(instance(queryBuilderMock));
    when(queryBuilderMock.where(anyString(), anything())).thenReturn(
      instance(queryBuilderMock),
    );
    when(queryBuilderMock.getRawMany()).thenResolve(result);
    const queryResult = await stockService.getTopStocksByGainers(limit);

    verify(queryBuilderMock.getRawMany()).once();

    expect(queryResult).toEqual(new StockRankResponses(result));
  });
```

### After
- 오류가 생기는 StockService의 생성자를 수정했습니다.
- 각 테스트마다 given으로 주어지는 데이터 값들을 쉽게 확인할 수 있게 변경했습니다.
-  describe() 블록을 추가하여 테스트들을 논리적 단위로 묶어주었습니다.
- given/when/then 주석을 추가하여 구조를 파악하기 쉽게 변경했습니다.
- 중복된 테스트를 제거했습니다.

```ts
test('주식 상승률 기준 상위 데이터를 반환한다.', async () => {
      // given
      const limit = 20;
      when(mockQueryBuilder.getRawMany()).thenResolve(stockList);

      // when
      const queryResult = await stockService.getTopStocksByGainers(limit);

      // then
      verify(mockQueryBuilder.getRawMany()).once();
      expect(queryResult).toEqual(new StockRankResponses(stockList));
    });
```


## 📸 스크린샷(FE만)

## 📌 이슈 사항

## 🟢 완료 조건

## ✍ 궁금한 점

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
