### PR TITLE
StockService에서 StockRepository와 UserStockRepository 계층 분리

### DIFF
--- a/packages/backend/src/stock/repository/stock.repository.ts
+++ b/packages/backend/src/stock/repository/stock.repository.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Like, Repository } from 'typeorm';
-import { Stock } from './domain/stock.entity';
+import { Stock } from '@/stock/domain/stock.entity';
 
 @Injectable()
 export class StockRepository {

--- a/packages/backend/src/stock/repository/userStock.repository.ts
+++ b/packages/backend/src/stock/repository/userStock.repository.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { UserStock } from '@/stock/domain/userStock.entity';
+import { Repository } from 'typeorm';
+
+@Injectable()
+export class UserStockRepository {
+  constructor(
+    @InjectRepository(UserStock)
+    private readonly userStockRepository: Repository<UserStock>,
+  ) {}
+
+  exists(userId: number, stockId: string) {
+    return this.userStockRepository.exists({
+      where: {
+        user: { id: userId },
+        stock: { id: stockId },
+      },
+    });
+  }
+
+  findByUserIdWithStock(userId: number) {
+    return this.userStockRepository.find({
+      where: {
+        user: { id: userId },
+      },
+      relations: ['stock'],
+    });
+  }
+
+  findByUserIdAndStockId(userId: number, stockId: string) {
+    return this.userStockRepository.findOne({
+      where: {
+        user: { id: userId },
+        stock: { id: stockId },
+      },
+      relations: ['user'],
+    });
+  }
+
+  create(userId: number, stockId: string) {
+    return this.userStockRepository.insert({
+      user: { id: userId },
+      stock: { id: stockId },
+    });
+  }
+
+  delete(userStockId: number) {
+    return this.userStockRepository.delete(userStockId);
+  }
+}

--- a/packages/backend/src/stock/stock.module.ts
+++ b/packages/backend/src/stock/stock.module.ts
@@ -22,7 +22,7 @@ import { OpenapiScraperModule } from '@/scraper/openapi/openapi-scraper.module';
 import { ScraperModule } from '@/scraper/scraper.module';
 import { StockDataCache } from '@/stock/cache/stockData.cache';
 import { StockDataService } from '@/stock/stockData.service';
-import { StockRepository } from '@/stock/stock.repository';
+import { StockRepository } from '@/stock/repository/stock.repository';
 import { UserStockRepository } from '@/stock/repository/userStock.repository';
 import { UserStock } from './domain/userStock.entity';
 

--- a/packages/backend/src/stock/stock.module.ts
+++ b/packages/backend/src/stock/stock.module.ts
@@ -22,12 +22,15 @@ import { OpenapiScraperModule } from '@/scraper/openapi/openapi-scraper.module';
 import { ScraperModule } from '@/scraper/scraper.module';
 import { StockDataCache } from '@/stock/cache/stockData.cache';
 import { StockDataService } from '@/stock/stockData.service';
-import { GainersSortStrategy, LosersSortStrategy, ViewsSortStrategy } from '@/stock/strategy/StockSortStrategy';
+import { StockRepository } from '@/stock/stock.repository';
+import { UserStockRepository } from '@/stock/repository/userStock.repository';
+import { UserStock } from './domain/userStock.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
       Stock,
+      UserStock,
       StockMinutely,
       StockDaily,
       StockWeekly,
@@ -50,9 +53,8 @@ import { GainersSortStrategy, LosersSortStrategy, ViewsSortStrategy } from '@/st
     StockDataService,
     StockDetailService,
     StockRateIndexService,
-    ViewsSortStrategy,
-    GainersSortStrategy,
-    LosersSortStrategy
+    StockRepository,
+    UserStockRepository,
   ],
   exports: [StockService],
 })

--- a/packages/backend/src/stock/stock.repository.ts
+++ b/packages/backend/src/stock/stock.repository.ts
@@ -1,0 +1,88 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Like, Repository } from 'typeorm';
+import { Stock } from './domain/stock.entity';
+
+@Injectable()
+export class StockRepository {
+  constructor(
+    @InjectRepository(Stock)
+    private readonly stockRepository: Repository<Stock>,
+  ) {}
+
+  existsById(id: string) {
+    return this.stockRepository.exists({ where: { id } });
+  }
+
+  findById(id: string) {
+    return this.stockRepository.findOne({ where: { id } });
+  }
+
+  findByName(id: string) {
+    return this.stockRepository.find({
+      where: {
+        isTrading: true,
+        name: Like(`%${id}%`),
+      },
+      take: 10,
+    });
+  }
+
+  findByTopViews(limit: number) {
+    return this.getStocksQuery()
+      .orderBy('stock.views', 'DESC')
+      .limit(limit)
+      .getRawMany();
+  }
+
+  findByTopGainers(limit: number) {
+    return this.getStocksQuery()
+      .innerJoinAndSelect('stock.fluctuationRankStocks', 'rank')
+      .where('rank.isRising = :isRising', { isRising: true })
+      .orderBy('rank.rank', 'ASC')
+      .limit(limit)
+      .getRawMany();
+  }
+
+  findByTopLosers(limit: number) {
+    return this.getStocksQuery()
+      .innerJoinAndSelect('stock.fluctuationRankStocks', 'rank')
+      .where('rank.isRising = :isRising', { isRising: false })
+      .orderBy('rank.rank', 'ASC')
+      .limit(limit)
+      .getRawMany();
+  }
+
+  findAllWithFluctuaions() {
+    return this.getStocksQuery()
+      .innerJoinAndSelect('stock.fluctuationRankStocks', 'rank')
+      .getRawMany();
+  }
+
+  async increaseView(id: string) {
+    await this.stockRepository.increment({ id }, 'views', 1);
+  }
+
+  private getStocksQuery() {
+    return this.stockRepository
+      .createQueryBuilder('stock')
+      .leftJoin(
+        'stock_live_data',
+        'stockLiveData',
+        'stock.id = stockLiveData.stock_id',
+      )
+      .leftJoin(
+        'stock_detail',
+        'stockDetail',
+        'stock.id = stockDetail.stock_id',
+      )
+      .select([
+        'stock.id AS id',
+        'stock.name AS name',
+        'stockLiveData.currentPrice AS currentPrice',
+        'stockLiveData.changeRate AS changeRate',
+        'stockLiveData.volume AS volume',
+        'stockDetail.marketCap AS marketCap',
+      ]);
+  }
+}

--- a/packages/backend/src/stock/stock.service.spec.ts
+++ b/packages/backend/src/stock/stock.service.spec.ts
@@ -19,207 +19,259 @@ import {
 } from './strategy/StockSortStrategy';
 
 describe('StockService 테스트', () => {
-  const stockId = '005930';
-  const userId = 1;
-  const result = [
-    {
-      id: '005930',
-      name: '삼성전자',
-      currentPrice: '100000.0',
-      changeRate: '2.5',
-      volume: '500000',
-      marketCap: '500000000000.00',
-    },
-    {
-      id: 'A051910',
-      name: 'LG화학',
-      currentPrice: '75000.0',
-      changeRate: '-1.2',
-      volume: '300000',
-      marketCap: '20000000000.00',
-    },
-  ];
-  let logger: Logger;
+  // mocked classes
+  let mockLogger: Logger;
   let mockDataSource: DataSource;
   let mockManager: EntityManager;
+  let mockQueryBuilder: SelectQueryBuilder<Stock>;
+  let mockRepository: Repository<Stock>;
+  let mockViewsSortStrategy: ViewsSortStrategy;
+  let mockGainersSortStrategy: GainersSortStrategy;
+  let mockLosersSortStrategy: LosersSortStrategy;
+
+  // test target
   let stockService: StockService;
-  let queryBuilderMock: SelectQueryBuilder<Stock>;
-  let repositoryMock: Repository<Stock>;
-  let viewsSortStrategy: ViewsSortStrategy;
-  let gainersSortStrategy: GainersSortStrategy;
-  let losersSortStrategy: LosersSortStrategy;
 
   beforeEach(() => {
     mockDataSource = mock(DataSource);
-    logger = mock(Logger);
     mockManager = mock(EntityManager);
-    queryBuilderMock = mock(SelectQueryBuilder);
-    viewsSortStrategy = mock(ViewsSortStrategy);
-    gainersSortStrategy = mock(GainersSortStrategy);
-    losersSortStrategy = mock(LosersSortStrategy);
+    mockQueryBuilder = mock(SelectQueryBuilder);
+    mockRepository = mock(Repository);
+
+    mockLogger = mock(Logger);
+    mockViewsSortStrategy = mock(ViewsSortStrategy);
+    mockGainersSortStrategy = mock(GainersSortStrategy);
+    mockLosersSortStrategy = mock(LosersSortStrategy);
+
     stockService = new StockService(
       instance(mockDataSource),
-      instance(logger),
-      instance(viewsSortStrategy),
-      instance(gainersSortStrategy),
-      instance(losersSortStrategy),
+      instance(mockLogger),
+      instance(mockViewsSortStrategy),
+      instance(mockGainersSortStrategy),
+      instance(mockLosersSortStrategy),
     );
-    repositoryMock = mock(Repository);
+
+    // stock service 내부에서 사용하는 typeorm 메서드 mocking
     when(mockDataSource.transaction(anything())).thenCall(async (callback) => {
       return await callback(instance(mockManager));
     });
-    when(queryBuilderMock.leftJoin(anything(), anything(), anything()))
-      .thenReturn(instance(queryBuilderMock))
-      .thenReturn(instance(queryBuilderMock));
-    when(queryBuilderMock.select(anything())).thenReturn(
-      instance(queryBuilderMock),
+    when(mockQueryBuilder.leftJoin(anything(), anything(), anything()))
+      .thenReturn(instance(mockQueryBuilder))
+      .thenReturn(instance(mockQueryBuilder));
+    when(mockQueryBuilder.select(anything())).thenReturn(
+      instance(mockQueryBuilder),
     );
-    when(queryBuilderMock.orderBy(anything(), anything())).thenReturn(
-      instance(queryBuilderMock),
+    when(mockQueryBuilder.orderBy(anything(), anything())).thenReturn(
+      instance(mockQueryBuilder),
     );
-    when(queryBuilderMock.limit(anything())).thenReturn(
-      instance(queryBuilderMock),
+    when(mockQueryBuilder.limit(anything())).thenReturn(
+      instance(mockQueryBuilder),
     );
-    when(repositoryMock.createQueryBuilder(anyString())).thenReturn(
-      instance(queryBuilderMock),
+    when(mockRepository.createQueryBuilder(anyString())).thenReturn(
+      instance(mockQueryBuilder),
     );
     when(mockDataSource.getRepository(anything())).thenReturn(
-      instance(repositoryMock),
+      instance(mockRepository),
     );
-  });
-
-  test('주식의 조회수를 증가시킨다.', async () => {
-    when(mockManager.exists(Stock, anything())).thenResolve(true);
-
-    await stockService.increaseView(stockId);
-
-    verify(mockManager.exists(Stock, anything())).once();
-    verify(mockManager.increment(Stock, anything(), 'views', 1)).once();
-  });
-
-  test('존재하지 않는 주식의 조회수를 증가시키려 하면 예외가 발생한다.', async () => {
-    when(mockManager.exists(Stock, anything())).thenResolve(false);
-
-    await expect(() => stockService.increaseView('1')).rejects.toThrow(
-      'stock not found',
-    );
-  });
-
-  test('유저 주식을 추가한다.', async () => {
-    when(mockManager.exists(Stock, anything())).thenResolve(true);
-    when(mockManager.exists(UserStock, anything())).thenResolve(false);
-
-    await stockService.createUserStock(userId, stockId);
-
-    verify(mockManager.exists(Stock, anything())).times(1);
-    verify(mockManager.exists(UserStock, anything())).times(1);
-    verify(mockManager.insert(UserStock, anything())).once();
-  });
-
-  test('유저 주식을 추가할 때 존재하지 않는 주식이면 예외가 발생한다.', async () => {
-    when(mockManager.exists(Stock, anything())).thenResolve(false);
-
-    await expect(() =>
-      stockService.createUserStock(userId, 'A'),
-    ).rejects.toThrow('not exists stock');
-  });
-
-  test('유저 주식을 추가할 때 이미 존재하는 유저 주식이면 예외가 발생한다.', async () => {
-    when(mockManager.exists(Stock, anything())).thenResolve(true);
-    when(mockManager.exists(UserStock, anything())).thenResolve(true);
-
-    await expect(async () =>
-      stockService.createUserStock(userId, stockId),
-    ).rejects.toThrow('user stock already exists');
-  });
-
-  test('유저 주식을 삭제한다.', async () => {
-    when(mockManager.findOne(UserStock, anything())).thenResolve({
-      id: 1,
-      user: { id: userId } as User,
-      stock: { id: stockId } as Stock,
-      date: {
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    });
-
-    await stockService.deleteUserStock(userId, stockId);
-
-    verify(mockManager.findOne(UserStock, anything())).once();
-    verify(mockManager.delete(UserStock, anything())).once();
-  });
-
-  test('유저 주식을 삭제 시 존재하지 않는 유저 주식이면 예외가 발생한다.', async () => {
-    when(mockManager.findOne(UserStock, anything())).thenResolve(null);
-
-    await expect(() =>
-      stockService.deleteUserStock(userId, '13'),
-    ).rejects.toThrow('user stock not found');
-  });
-
-  test('유저 주식을 삭제 시 주인이 아닐 때 예외가 발생한다.', async () => {
-    const notOwnerUserId = 2;
-    when(mockManager.findOne(UserStock, anything())).thenResolve({
-      id: 1,
-      user: { id: userId } as User,
-      stock: { id: stockId } as Stock,
-      date: {
-        createdAt: new Date(),
-        updatedAt: new Date(),
-      },
-    });
-
-    await expect(() =>
-      stockService.deleteUserStock(notOwnerUserId, stockId),
-    ).rejects.toThrow('you are not owner of user stock');
-  });
-
-  test('소유 주식인지 확인한다.', async () => {
-    when(mockManager.exists(UserStock, anything())).thenResolve(true);
-    const result = await stockService.isUserStockOwner(stockId, userId);
-
-    expect(result).toBe(true);
-  });
-
-  test('인증된 유저가 아니면 소유 주식은 항상 false를 반환한다.', async () => {
-    const result = await stockService.isUserStockOwner(stockId);
-
-    expect(result).toBe(false);
-  });
-
-  test('주식 조회수 기준 상위 데이터를 반환한다.', async () => {
-    const limit = 5;
-
-    when(queryBuilderMock.getRawMany()).thenResolve(result);
-
-    const queryResult = await stockService.getTopStocksByViews(limit);
-
-    expect(queryResult).toStrictEqual(
-      plainToInstance(StocksResponse, queryResult),
-    );
-    verify(queryBuilderMock.getRawMany()).once();
-  });
-
-  test('주식 상승률 기준 상위 데이터를 반환한다.', async () => {
-    const limit = 20;
     when(
-      queryBuilderMock.innerJoinAndSelect(anyString(), anyString()),
-    ).thenReturn(instance(queryBuilderMock));
-    when(queryBuilderMock.where(anyString(), anything())).thenReturn(
-      instance(queryBuilderMock),
+      mockQueryBuilder.innerJoinAndSelect(anyString(), anyString()),
+    ).thenReturn(instance(mockQueryBuilder));
+    when(mockQueryBuilder.where(anyString(), anything())).thenReturn(
+      instance(mockQueryBuilder),
     );
-    when(queryBuilderMock.getRawMany()).thenResolve(result);
-    const queryResult = await stockService.getTopStocksByGainers(limit);
-
-    verify(queryBuilderMock.getRawMany()).once();
-
-    expect(queryResult).toEqual(new StockRankResponses(result));
   });
 
-  test('인증된 유저가 아니면 소유 주식은 항상 false를 반환한다.', async () => {
-    const result = await stockService.isUserStockOwner(stockId);
+  describe('주식 조회수', () => {
+    test('주식의 조회수를 증가시킨다.', async () => {
+      // given
+      const stockId = '005930';
+      when(mockManager.exists(Stock, anything())).thenResolve(true);
 
-    expect(result).toBe(false);
+      // when
+      await stockService.increaseView(stockId);
+
+      // then
+      verify(mockManager.exists(Stock, anything())).once();
+      verify(mockManager.increment(Stock, anything(), 'views', 1)).once();
+    });
+
+    test('존재하지 않는 주식의 조회수를 증가시키려 하면 예외가 발생한다.', async () => {
+      // given
+      when(mockManager.exists(Stock, anything())).thenResolve(false);
+
+      // when & then
+      await expect(() => stockService.increaseView('1')).rejects.toThrow(
+        'stock not found',
+      );
+    });
+  });
+
+  describe('유저 주식 관리', () => {
+    test('유저 주식을 추가한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      when(mockManager.exists(Stock, anything())).thenResolve(true);
+      when(mockManager.exists(UserStock, anything())).thenResolve(false);
+
+      // when
+      await stockService.createUserStock(userId, stockId);
+
+      // then
+      verify(mockManager.exists(Stock, anything())).times(1);
+      verify(mockManager.exists(UserStock, anything())).times(1);
+      verify(mockManager.insert(UserStock, anything())).once();
+    });
+
+    test('유저 주식을 추가할 때 존재하지 않는 주식이면 예외가 발생한다.', async () => {
+      // given
+      const userId = 1;
+      when(mockManager.exists(Stock, anything())).thenResolve(false);
+
+      // when & then
+      await expect(() =>
+        stockService.createUserStock(userId, 'A'),
+      ).rejects.toThrow('not exists stock');
+    });
+
+    test('유저 주식을 추가할 때 이미 존재하는 유저 주식이면 예외가 발생한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      when(mockManager.exists(Stock, anything())).thenResolve(true);
+      when(mockManager.exists(UserStock, anything())).thenResolve(true);
+
+      // when & then
+      await expect(async () =>
+        stockService.createUserStock(userId, stockId),
+      ).rejects.toThrow('user stock already exists');
+    });
+
+    test('유저 주식을 삭제한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      when(mockManager.findOne(UserStock, anything())).thenResolve({
+        id: 1,
+        user: { id: userId } as User,
+        stock: { id: stockId } as Stock,
+        date: {
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      // when
+      await stockService.deleteUserStock(userId, stockId);
+
+      // then
+      verify(mockManager.findOne(UserStock, anything())).once();
+      verify(mockManager.delete(UserStock, anything())).once();
+    });
+
+    test('유저 주식을 삭제 시 존재하지 않는 유저 주식이면 예외가 발생한다.', async () => {
+      // given
+      const userId = 1;
+      when(mockManager.findOne(UserStock, anything())).thenResolve(null);
+
+      // when & then
+      await expect(() =>
+        stockService.deleteUserStock(userId, '13'),
+      ).rejects.toThrow('user stock not found');
+    });
+
+    test('유저 주식을 삭제 시 주인이 아닐 때 예외가 발생한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      const notOwnerUserId = 2;
+      when(mockManager.findOne(UserStock, anything())).thenResolve({
+        id: 1,
+        user: { id: userId } as User,
+        stock: { id: stockId } as Stock,
+        date: {
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      });
+
+      // when & then
+      await expect(() =>
+        stockService.deleteUserStock(notOwnerUserId, stockId),
+      ).rejects.toThrow('you are not owner of user stock');
+    });
+
+    test('소유 주식인지 확인한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      when(mockManager.exists(UserStock, anything())).thenResolve(true);
+
+      // when
+      const result = await stockService.isUserStockOwner(stockId, userId);
+
+      // then
+      expect(result).toBe(true);
+    });
+
+    test('인증된 유저가 아니면 소유 주식은 항상 false를 반환한다.', async () => {
+      // given
+      const stockId = '005930';
+      const userId = undefined;
+
+      // when
+      const result = await stockService.isUserStockOwner(stockId, userId);
+
+      // then
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('주식 검색', () => {
+    const stockList = [
+      {
+        id: '005930',
+        name: '삼성전자',
+        currentPrice: '100000.0',
+        changeRate: '2.5',
+        volume: '500000',
+        marketCap: '500000000000.00',
+      },
+      {
+        id: 'A051910',
+        name: 'LG화학',
+        currentPrice: '75000.0',
+        changeRate: '-1.2',
+        volume: '300000',
+        marketCap: '20000000000.00',
+      },
+    ];
+
+    test('주식 조회수 기준 상위 데이터를 반환한다.', async () => {
+      //given
+      const limit = 5;
+      when(mockQueryBuilder.getRawMany()).thenResolve(stockList);
+
+      // when
+      const queryResult = await stockService.getTopStocksByViews(limit);
+
+      // then
+      expect(queryResult).toStrictEqual(
+        plainToInstance(StocksResponse, queryResult),
+      );
+    });
+
+    test('주식 상승률 기준 상위 데이터를 반환한다.', async () => {
+      // given
+      const limit = 20;
+      when(mockQueryBuilder.getRawMany()).thenResolve(stockList);
+
+      // when
+      const queryResult = await stockService.getTopStocksByGainers(limit);
+
+      // then
+      verify(mockQueryBuilder.getRawMany()).once();
+      expect(queryResult).toEqual(new StockRankResponses(stockList));
+    });
   });
 });

--- a/packages/backend/src/stock/stock.service.spec.ts
+++ b/packages/backend/src/stock/stock.service.spec.ts
@@ -12,6 +12,11 @@ import { StockService } from './stock.service';
 import { UserStock } from '@/stock/domain/userStock.entity';
 import { StockRankResponses, StocksResponse } from '@/stock/dto/stock.response';
 import { User } from '@/user/domain/user.entity';
+import {
+  GainersSortStrategy,
+  LosersSortStrategy,
+  ViewsSortStrategy,
+} from './strategy/StockSortStrategy';
 
 describe('StockService 테스트', () => {
   const stockId = '005930';
@@ -40,13 +45,25 @@ describe('StockService 테스트', () => {
   let stockService: StockService;
   let queryBuilderMock: SelectQueryBuilder<Stock>;
   let repositoryMock: Repository<Stock>;
+  let viewsSortStrategy: ViewsSortStrategy;
+  let gainersSortStrategy: GainersSortStrategy;
+  let losersSortStrategy: LosersSortStrategy;
 
   beforeEach(() => {
     mockDataSource = mock(DataSource);
     logger = mock(Logger);
     mockManager = mock(EntityManager);
     queryBuilderMock = mock(SelectQueryBuilder);
-    stockService = new StockService(instance(mockDataSource), logger);
+    viewsSortStrategy = mock(ViewsSortStrategy);
+    gainersSortStrategy = mock(GainersSortStrategy);
+    losersSortStrategy = mock(LosersSortStrategy);
+    stockService = new StockService(
+      instance(mockDataSource),
+      instance(logger),
+      instance(viewsSortStrategy),
+      instance(gainersSortStrategy),
+      instance(losersSortStrategy),
+    );
     repositoryMock = mock(Repository);
     when(mockDataSource.transaction(anything())).thenCall(async (callback) => {
       return await callback(instance(mockManager));

--- a/packages/backend/src/stock/stock.service.ts
+++ b/packages/backend/src/stock/stock.service.ts
@@ -8,7 +8,7 @@ import {
 } from './dto/stock.response';
 import { UserStock } from '@/stock/domain/userStock.entity';
 import { UserStocksResponse } from '@/stock/dto/userStock.response';
-import { StockRepository } from '@/stock/stock.repository';
+import { StockRepository } from '@/stock/repository/stock.repository';
 import { UserStockRepository } from '@/stock/repository/userStock.repository';
 
 @Injectable()

--- a/packages/backend/src/stock/stock.service.ts
+++ b/packages/backend/src/stock/stock.service.ts
@@ -28,55 +28,13 @@ export class StockService {
     return this.stockRepository.increaseView(stockId);
   }
 
-  async createUserStock(userId: number, stockId: string) {
-    await this.validateStockExists(stockId);
-    await this.validateDuplicateUserStock(stockId, userId);
-    return this.userStockRepository.create(userId, stockId);
-  }
-
-  async isUserStockOwner(stockId: string, userId?: number) {
-    if (!userId) {
-      return false;
-    }
-    return this.userStockRepository.exists(userId, stockId);
-  }
-
-  async getUserStocks(userId?: number) {
-    if (!userId) {
-      return new UserStocksResponse([]);
-    }
-    const result = await this.userStockRepository.findByUserIdWithStock(userId);
-    return new UserStocksResponse(result);
-  }
-
   checkStockExist(stockId: string) {
     return this.stockRepository.existsById(stockId);
-  }
-
-  async deleteUserStock(userId: number, stockId: string) {
-    const userStock = await this.userStockRepository.findByUserIdAndStockId(
-      userId,
-      stockId,
-    );
-    this.validateUserStock(userId, userStock);
-    await this.userStockRepository.delete(userStock!.id);
   }
 
   async searchStock(stockName: string) {
     const result = await this.stockRepository.findByName(stockName);
     return new StockSearchResponse(result);
-  }
-
-  validateUserStock(userId: number, userStock: UserStock | null) {
-    if (!userStock) {
-      throw new BadRequestException('user stock not found');
-    }
-    if (!userStock.user) {
-      throw new Error('Invalid user stock row');
-    }
-    if (userStock.user.id !== userId) {
-      throw new BadRequestException('you are not owner of user stock');
-    }
   }
 
   async getTopStocks(sortBy: string, limit: number) {
@@ -117,6 +75,48 @@ export class StockService {
   private async validateStockExists(stockId: string) {
     if (!(await this.stockRepository.existsById(stockId))) {
       throw new BadRequestException('not exists stock');
+    }
+  }
+
+  async createUserStock(userId: number, stockId: string) {
+    await this.validateStockExists(stockId);
+    await this.validateDuplicateUserStock(stockId, userId);
+    return this.userStockRepository.create(userId, stockId);
+  }
+  
+  async isUserStockOwner(stockId: string, userId?: number) {
+    if (!userId) {
+      return false;
+    }
+    return this.userStockRepository.exists(userId, stockId);
+  }
+
+  async getUserStocks(userId?: number) {
+    if (!userId) {
+      return new UserStocksResponse([]);
+    }
+    const result = await this.userStockRepository.findByUserIdWithStock(userId);
+    return new UserStocksResponse(result);
+  }
+
+  async deleteUserStock(userId: number, stockId: string) {
+    const userStock = await this.userStockRepository.findByUserIdAndStockId(
+      userId,
+      stockId,
+    );
+    this.validateUserStock(userId, userStock);
+    await this.userStockRepository.delete(userStock!.id);
+  }
+
+  validateUserStock(userId: number, userStock: UserStock | null) {
+    if (!userStock) {
+      throw new BadRequestException('user stock not found');
+    }
+    if (!userStock.user) {
+      throw new Error('Invalid user stock row');
+    }
+    if (userStock.user.id !== userId) {
+      throw new BadRequestException('you are not owner of user stock');
     }
   }
 


### PR DESCRIPTION
- close #26 

## ✅ 작업 내용

## 문제 상황

- 현재 코드에서는 StockService 클래스에서 Stock 엔티티에 대한 repository 기능과 UserStock 엔티티에 대한 repository 기능까지 함께 부담하고 있어서 하나의 클래스에 너무 많은 책임이 부여되어 있었습니다.
- 이에 따라 StockServcie에 대한 단위 테스트를 작성할 때도 typeorm 메서드에 대한 mocking이 생각 이상으로 많이 발생하는 문제 있었습니다.
- 또한, StockService의 기능을 파악할 때도 핵심 로직을 파악하기 힘들었습니다.

## StockRepository 분리하기

- 기존에는 StockService에서 담당하고 있는 queryBuilder 작업을 Repository 계층으로 위임했습니다.

### Before

[StockService]

```tsx
export class StockService {
  constructor(
    private readonly datasource: DataSource,
    @Inject('winston') private readonly logger: Logger,
  ) {}
  
	...
	
	async getTopStocksByViews(limit: number) {
    const rawData = await this.getStocksQuery()
      .orderBy('stock.views', 'DESC')
      .limit(limit)
      .getRawMany();

    return plainToInstance(StocksResponse, rawData);
  }
  
	private getStocksQuery() {
	    return this.datasource
	      .getRepository(Stock)
	      .createQueryBuilder('stock')
	      .leftJoin(
	        'stock_live_data',
	        'stockLiveData',
	        'stock.id = stockLiveData.stock_id',
	      )
	      .leftJoin(
	        'stock_detail',
	        'stockDetail',
	        'stock.id = stockDetail.stock_id',
	      )
	      .select([
	        'stock.id AS id',
	        'stock.name AS name',
	        'stockLiveData.currentPrice AS currentPrice',
	        'stockLiveData.changeRate AS changeRate',
	        'stockLiveData.volume AS volume',
	        'stockDetail.marketCap AS marketCap',
	      ]);
	  }
}
```

### After

[StockService]

```tsx
export class StockService {
  constructor(
    private readonly stockRepository: StockRepository,
    private readonly userStockRepository: UserStockRepository,
    @Inject('winston') private readonly logger: Logger,
  ) {}
  
  ...
  
  async getTopStocksByViews(limit: number) {
    const rawData = await this.stockRepository.findByTopViews(limit);
    return plainToInstance(StocksResponse, rawData);
  }
  
  
```

[StockRepository]

```tsx
export class StockRepository {
  constructor(
    @InjectRepository(Stock)
    private readonly stockRepository: Repository<Stock>,
  ) {}
  
  ...
  
  findByTopViews(limit: number) {
    return this.getStocksQuery()
      .orderBy('stock.views', 'DESC')
      .limit(limit)
      .getRawMany();
  }
  
  private getStocksQuery() {
    return this.stockRepository
      .createQueryBuilder('stock')
      .leftJoin(
        'stock_live_data',
        'stockLiveData',
        'stock.id = stockLiveData.stock_id',
      )
      .leftJoin(
        'stock_detail',
        'stockDetail',
        'stock.id = stockDetail.stock_id',
      )
      .select([
        'stock.id AS id',
        'stock.name AS name',
        'stockLiveData.currentPrice AS currentPrice',
        'stockLiveData.changeRate AS changeRate',
        'stockLiveData.volume AS volume',
        'stockDetail.marketCap AS marketCap',
      ]);
  }
}
```

## 불필요한 트랜잭션 제거



## 📸 스크린샷(FE만)

## 📌 이슈 사항

## 🟢 완료 조건

## ✍ 궁금한 점

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
