### PR TITLE
StockService 단위 테스트를 변경된 StockService 구조에 맞게 변경

### DIFF
--- a/packages/backend/src/stock/stock.service.spec.ts
+++ b/packages/backend/src/stock/stock.service.spec.ts
@@ -1,9 +1,13 @@
 import { plainToInstance } from 'class-transformer';
-import { anyNumber, anyString, instance, mock, verify, when } from 'ts-mockito';
+import { instance, mock, verify, when } from 'ts-mockito';
 import { Logger } from 'winston';
 import { Stock } from './domain/stock.entity';
 import { StockService } from './stock.service';
-import { StockRankResponses, StocksResponse } from '@/stock/dto/stock.response';
+import {
+  StockRankResponses,
+  StockSearchResponse,
+  StocksResponse,
+} from '@/stock/dto/stock.response';
 import { User } from '@/user/domain/user.entity';
 import { StockRepository } from './repository/stock.repository';
 import { UserStockRepository } from './repository/userStock.repository';
@@ -33,175 +37,29 @@ describe('StockService 테스트', () => {
     test('주식의 조회수를 증가시킨다.', async () => {
       // given
       const stockId = '005930';
-      when(mockStockRepository.existsById(anyString())).thenResolve(true);
+      when(mockStockRepository.existsById(stockId)).thenResolve(true);
 
       // when
       await stockService.increaseView(stockId);
 
       // then
-      verify(mockStockRepository.existsById(anyString())).once();
-      verify(mockStockRepository.increaseView(anyString())).once();
+      verify(mockStockRepository.existsById(stockId)).once();
+      verify(mockStockRepository.increaseView(stockId)).once();
     });
 
     test('존재하지 않는 주식의 조회수를 증가시키려 하면 예외가 발생한다.', async () => {
       // given
-      when(mockStockRepository.existsById(anyString())).thenResolve(false);
+      const nonExistStock = '1';
+      when(mockStockRepository.existsById(nonExistStock)).thenResolve(false);
 
       // when & then
-      await expect(() => stockService.increaseView('1')).rejects.toThrow(
-        'stock not found',
-      );
+      await expect(() =>
+        stockService.increaseView(nonExistStock),
+      ).rejects.toThrow('stock not found');
     });
   });
 
-  describe('유저 주식 관리', () => {
-    test('유저 주식을 추가한다.', async () => {
-      // given
-      const userId = 1;
-      const stockId = '005930';
-      when(mockStockRepository.existsById(anyString())).thenResolve(true);
-      when(
-        mockUserStockRepository.exists(anyNumber(), anyString()),
-      ).thenResolve(false);
-
-      // when
-      await stockService.createUserStock(userId, stockId);
-
-      // then
-      verify(mockStockRepository.existsById(anyString())).times(1);
-      verify(mockUserStockRepository.exists(anyNumber(), anyString())).times(1);
-      verify(mockUserStockRepository.create(anyNumber(), anyString())).once();
-    });
-
-    test('유저 주식을 추가할 때 존재하지 않는 주식이면 예외가 발생한다.', async () => {
-      // given
-      const userId = 1;
-      when(mockStockRepository.existsById(anyString())).thenResolve(false);
-
-      // when & then
-      await expect(() =>
-        stockService.createUserStock(userId, 'A'),
-      ).rejects.toThrow('not exists stock');
-    });
-
-    test('유저 주식을 추가할 때 이미 존재하는 유저 주식이면 예외가 발생한다.', async () => {
-      // given
-      const userId = 1;
-      const stockId = '005930';
-      when(mockStockRepository.existsById(anyString())).thenResolve(true);
-      when(
-        mockUserStockRepository.exists(anyNumber(), anyString()),
-      ).thenResolve(true);
-
-      // when & then
-      await expect(async () =>
-        stockService.createUserStock(userId, stockId),
-      ).rejects.toThrow('user stock already exists');
-    });
-
-    test('유저 주식을 삭제한다.', async () => {
-      // given
-      const userId = 1;
-      const stockId = '005930';
-      when(
-        mockUserStockRepository.findByUserIdAndStockId(
-          anyNumber(),
-          anyString(),
-        ),
-      ).thenResolve({
-        id: 1,
-        user: { id: userId } as User,
-        stock: { id: stockId } as Stock,
-        date: {
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
-      });
-
-      // when
-      await stockService.deleteUserStock(userId, stockId);
-
-      // then
-      verify(
-        mockUserStockRepository.findByUserIdAndStockId(
-          anyNumber(),
-          anyString(),
-        ),
-      ).once();
-      verify(mockUserStockRepository.delete(anyNumber())).once();
-    });
-
-    test('유저 주식을 삭제 시 존재하지 않는 유저 주식이면 예외가 발생한다.', async () => {
-      // given
-      const userId = 1;
-      when(
-        mockUserStockRepository.findByUserIdAndStockId(
-          anyNumber(),
-          anyString(),
-        ),
-      ).thenResolve(null);
-
-      // when & then
-      await expect(() =>
-        stockService.deleteUserStock(userId, '13'),
-      ).rejects.toThrow('user stock not found');
-    });
-
-    test('유저 주식을 삭제 시 주인이 아닐 때 예외가 발생한다.', async () => {
-      // given
-      const userId = 1;
-      const stockId = '005930';
-      const notOwnerUserId = 2;
-      when(
-        mockUserStockRepository.findByUserIdAndStockId(
-          anyNumber(),
-          anyString(),
-        ),
-      ).thenResolve({
-        id: 1,
-        user: { id: userId } as User,
-        stock: { id: stockId } as Stock,
-        date: {
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
-      });
-
-      // when & then
-      await expect(() =>
-        stockService.deleteUserStock(notOwnerUserId, stockId),
-      ).rejects.toThrow('you are not owner of user stock');
-    });
-
-    test('소유 주식인지 확인한다.', async () => {
-      // given
-      const userId = 1;
-      const stockId = '005930';
-      when(
-        mockUserStockRepository.exists(anyNumber(), anyString()),
-      ).thenResolve(true);
-
-      // when
-      const result = await stockService.isUserStockOwner(stockId, userId);
-
-      // then
-      expect(result).toBe(true);
-    });
-
-    test('인증된 유저가 아니면 소유 주식은 항상 false를 반환한다.', async () => {
-      // given
-      const stockId = '005930';
-      const userId = undefined;
-
-      // when
-      const result = await stockService.isUserStockOwner(stockId, userId);
-
-      // then
-      expect(result).toBe(false);
-    });
-  });
-
-  describe('주식 검색', () => {
+  describe('주식 정렬 조회', () => {
     const stockList = [
       {
         id: '005930',
@@ -224,10 +82,11 @@ describe('StockService 테스트', () => {
     test('주식 조회수 기준 상위 데이터를 반환한다.', async () => {
       //given
       const limit = 5;
+      const sortBy = 'views';
       when(mockStockRepository.findByTopViews(limit)).thenResolve(stockList);
 
       // when
-      const queryResult = await stockService.getTopStocksByViews(limit);
+      const queryResult = await stockService.getTopStocks(sortBy, limit);
 
       // then
       expect(queryResult).toStrictEqual(
@@ -238,14 +97,194 @@ describe('StockService 테스트', () => {
     test('주식 상승률 기준 상위 데이터를 반환한다.', async () => {
       // given
       const limit = 20;
+      const sortBy = 'gainers';
       when(mockStockRepository.findByTopGainers(limit)).thenResolve(stockList);
 
       // when
-      const queryResult = await stockService.getTopStocksByGainers(limit);
+      const queryResult = await stockService.getTopStocks(sortBy, limit);
 
       // then
-      verify(mockStockRepository.findByTopGainers(anyNumber())).once();
+      verify(mockStockRepository.findByTopGainers(limit)).once();
       expect(queryResult).toEqual(new StockRankResponses(stockList));
+    });
+
+    test('주식 하락률 기준 상위 데이터를 반환한다.', async () => {
+      // given
+      const limit = 20;
+      const sortBy = 'losers';
+      when(mockStockRepository.findByTopLosers(limit)).thenResolve(stockList);
+
+      // when
+      const queryResult = await stockService.getTopStocks(sortBy, limit);
+
+      // then
+      verify(mockStockRepository.findByTopLosers(limit)).once();
+      expect(queryResult).toEqual(new StockRankResponses(stockList));
+    });
+
+    test('주식 정렬 전략이 잘못된 요청은 예외가 발생한다.', async () => {
+      // given
+      const limit = 20;
+      const wrongSortBy = 'infinite';
+
+      // when & then
+      await expect(() =>
+        stockService.getTopStocks(wrongSortBy, limit),
+      ).rejects.toThrow(`Unknown sort strategy: ${wrongSortBy}`);
+    });
+  });
+
+  describe('주식 정보 조회', () => {
+    test('주식 이름으로 주식을 검색한다.', async () => {
+      // given
+      const stockName = '삼성';
+      const mockStocks = [
+        { id: '005930', name: '삼성전자', views: 3 } as Stock,
+        { id: '006400', name: '삼성SDI', views: 1 } as Stock,
+      ];
+      when(mockStockRepository.findByName(stockName)).thenResolve(mockStocks);
+
+      // when
+      const result = await stockService.searchStock(stockName);
+
+      // then
+      expect(result).toEqual(new StockSearchResponse(mockStocks));
+    });
+  });
+
+  describe('유저 주식 추가', () => {
+    test('유저 주식을 추가한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      when(mockStockRepository.existsById(stockId)).thenResolve(true);
+      when(mockUserStockRepository.exists(userId, stockId)).thenResolve(false);
+
+      // when
+      await stockService.createUserStock(userId, stockId);
+
+      // then
+      verify(mockStockRepository.existsById(stockId)).once();
+      verify(mockUserStockRepository.exists(userId, stockId)).once();
+      verify(mockUserStockRepository.create(userId, stockId)).once();
+    });
+
+    test('유저 주식을 추가할 때 존재하지 않는 주식이면 예외가 발생한다.', async () => {
+      // given
+      const userId = 1;
+      const nonExistStock = 'A';
+      when(mockStockRepository.existsById(nonExistStock)).thenResolve(false);
+
+      // when & then
+      await expect(() =>
+        stockService.createUserStock(userId, nonExistStock),
+      ).rejects.toThrow('not exists stock');
+    });
+
+    test('유저 주식을 추가할 때 이미 존재하는 유저 주식이면 예외가 발생한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      when(mockStockRepository.existsById(stockId)).thenResolve(true);
+      when(mockUserStockRepository.exists(userId, stockId)).thenResolve(true);
+
+      // when & then
+      await expect(async () =>
+        stockService.createUserStock(userId, stockId),
+      ).rejects.toThrow('user stock already exists');
+    });
+  });
+
+  describe('유저 주식 삭제', () => {
+    test('유저 주식을 삭제한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      const userStock = {
+        id: 10,
+        user: { id: userId } as User,
+        stock: { id: stockId } as Stock,
+        date: {
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      };
+      when(
+        mockUserStockRepository.findByUserIdAndStockId(userId, stockId),
+      ).thenResolve(userStock);
+
+      // when
+      await stockService.deleteUserStock(userId, stockId);
+
+      // then
+      verify(
+        mockUserStockRepository.findByUserIdAndStockId(userId, stockId),
+      ).once();
+      verify(mockUserStockRepository.delete(userStock.id)).once();
+    });
+
+    test('유저 주식을 삭제 시 존재하지 않는 유저 주식이면 예외가 발생한다.', async () => {
+      // given
+      const userId = 1;
+      const nonUserStock = '005930';
+      when(
+        mockUserStockRepository.findByUserIdAndStockId(userId, nonUserStock),
+      ).thenResolve(null);
+
+      // when & then
+      await expect(() =>
+        stockService.deleteUserStock(userId, nonUserStock),
+      ).rejects.toThrow('user stock not found');
+    });
+
+    test('유저 주식을 삭제 시 주인이 아닐 때 예외가 발생한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      const userStock = {
+        id: 13,
+        user: { id: 2 } as User,
+        stock: { id: stockId } as Stock,
+        date: {
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      };
+      when(
+        mockUserStockRepository.findByUserIdAndStockId(userId, stockId),
+      ).thenResolve(userStock);
+
+      // when & then
+      await expect(() =>
+        stockService.deleteUserStock(userId, stockId),
+      ).rejects.toThrow('you are not owner of user stock');
+    });
+  });
+
+  describe('유저 주식 조회', () => {
+    test('소유 주식인지 확인한다.', async () => {
+      // given
+      const userId = 1;
+      const stockId = '005930';
+      when(mockUserStockRepository.exists(userId, stockId)).thenResolve(true);
+
+      // when
+      const result = await stockService.isUserStockOwner(stockId, userId);
+
+      // then
+      expect(result).toBe(true);
+    });
+
+    test('인증된 유저가 아니면 소유 주식은 항상 false를 반환한다.', async () => {
+      // given
+      const stockId = '005930';
+      const userId = undefined;
+
+      // when
+      const result = await stockService.isUserStockOwner(stockId, userId);
+
+      // then
+      expect(result).toBe(false);
     });
   });
 });


### PR DESCRIPTION
- close #28 

## ✅ 작업 내용

### 변경된 StockService 구조에 맞게 단위테스트 코드 수정

- 기존 테스트 코드는 StockService에서 Repository 계층을 분리하기 전을 기준으로 작성되어 있었습니다.
- typeorm 메서드를 직접 서비스 계층에서 호출하다보니 너무 많은 mocking이 필요했고, 가독성이 떨어졌습니다.
- repository 계층을 분리하면서 테스트 코드도 간결하게 작성할 수 있었습니다.

#### Before

```ts
describe('StockService 테스트', () => {
  // mocked classes
  let mockLogger: Logger;
  let mockDataSource: DataSource;
  let mockManager: EntityManager;
  let mockQueryBuilder: SelectQueryBuilder<Stock>;
  let mockRepository: Repository<Stock>;
  let mockViewsSortStrategy: ViewsSortStrategy;
  let mockGainersSortStrategy: GainersSortStrategy;
  let mockLosersSortStrategy: LosersSortStrategy;

  // test target
  let stockService: StockService;

  beforeEach(() => {
    mockDataSource = mock(DataSource);
    mockManager = mock(EntityManager);
    mockQueryBuilder = mock(SelectQueryBuilder);
    mockRepository = mock(Repository);

    mockLogger = mock(Logger);
    mockViewsSortStrategy = mock(ViewsSortStrategy);
    mockGainersSortStrategy = mock(GainersSortStrategy);
    mockLosersSortStrategy = mock(LosersSortStrategy);

    stockService = new StockService(
      instance(mockDataSource),
      instance(mockLogger),
      instance(mockViewsSortStrategy),
      instance(mockGainersSortStrategy),
      instance(mockLosersSortStrategy),
    );

    // stock service 내부에서 사용하는 typeorm 메서드 mocking
    when(mockDataSource.transaction(anything())).thenCall(async (callback) => {
      return await callback(instance(mockManager));
    });
    when(mockQueryBuilder.leftJoin(anything(), anything(), anything()))
      .thenReturn(instance(mockQueryBuilder))
      .thenReturn(instance(mockQueryBuilder));
    when(mockQueryBuilder.select(anything())).thenReturn(
      instance(mockQueryBuilder),
    );
    when(mockQueryBuilder.orderBy(anything(), anything())).thenReturn(
      instance(mockQueryBuilder),
    );
    when(mockQueryBuilder.limit(anything())).thenReturn(
      instance(mockQueryBuilder),
    );
    when(mockRepository.createQueryBuilder(anyString())).thenReturn(
      instance(mockQueryBuilder),
    );
    when(mockDataSource.getRepository(anything())).thenReturn(
      instance(mockRepository),
    );
    when(
      mockQueryBuilder.innerJoinAndSelect(anyString(), anyString()),
    ).thenReturn(instance(mockQueryBuilder));
    when(mockQueryBuilder.where(anyString(), anything())).thenReturn(
      instance(mockQueryBuilder),
    );
  });
```

#### After

```ts
describe('StockService 테스트', () => {
  // mocked classes
  let mockLogger: Logger;
  let mockStockRepository: StockRepository;
  let mockUserStockRepository: UserStockRepository;

  // test target
  let stockService: StockService;

  beforeEach(() => {
    mockStockRepository = mock(StockRepository);
    mockUserStockRepository = mock(UserStockRepository);
    mockLogger = mock(Logger);

    stockService = new StockService(
      instance(mockStockRepository),
      instance(mockUserStockRepository),
      instance(mockLogger),
    );
  });
```

### 테스트 추가

- 기존에 존재하지 않던 하락률 기준 정렬 테스트와 존재하지 않는 정렬 전략에 대한 테스트를 추가했습니다

```ts
test('주식 하락률 기준 상위 데이터를 반환한다.', async () => {
  // given
  const limit = 20;
  const sortBy = 'losers';
  when(mockStockRepository.findByTopLosers(limit)).thenResolve(stockList);

  // when
  const queryResult = await stockService.getTopStocks(sortBy, limit);

  // then
  verify(mockStockRepository.findByTopLosers(limit)).once();
  expect(queryResult).toEqual(new StockRankResponses(stockList));
});

test('주식 정렬 전략이 잘못된 요청은 예외가 발생한다.', async () => {
  // given
  const limit = 20;
  const wrongSortBy = 'infinite';

  // when & then
  await expect(() =>
    stockService.getTopStocks(wrongSortBy, limit),
  ).rejects.toThrow(`Unknown sort strategy: ${wrongSortBy}`);
});
```



## 📸 스크린샷(FE만)

## 📌 이슈 사항

## 🟢 완료 조건

## ✍ 궁금한 점

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
