### PR TITLE
Feat #53 add filter news category

### DIFF
--- a/packages/backend/src/news/dto/crawlNewsItem.dto.ts
+++ b/packages/backend/src/news/dto/crawlNewsItem.dto.ts
@@ -1,4 +1,5 @@
 export class CrawlNewsItemDto {
+  category: string;
   date: string;
   title: string;
   content: string;

--- a/packages/backend/src/news/newsCrawling.service.ts
+++ b/packages/backend/src/news/newsCrawling.service.ts
@@ -61,10 +61,16 @@ export class NewsCrawlingService {
           const category = $(
             'li.Nlist_item._LNB_ITEM.is_active .Nitem_link_menu',
           ).text();
+          if (
+            category !== this.category.ECONOMICS &&
+            category !== this.category.IT &&
+            category !== this.category.WORLD
+          ) {
+            return null;
+          }
           const date = $('span._ARTICLE_DATE_TIME').attr('data-date-time');
           const title = $('#title_area').text();
           const content = $('#dic_area').text();
-
 
           return {
             category: category,
@@ -78,13 +84,7 @@ export class NewsCrawlingService {
     );
     return {
       stockName: stock,
-      news: crawledNews.filter((n) => {
-        return (
-          n.category === this.category.ECONOMICS ||
-          n.category === this.category.IT ||
-          n.category === this.category.WORLD
-        );
-      }),
+      news: crawledNews.filter((n) => n !== null),
     } as CrawlingDataDto;
   }
 }

--- a/packages/backend/src/news/newsCrawling.service.ts
+++ b/packages/backend/src/news/newsCrawling.service.ts
@@ -12,7 +12,7 @@ export class NewsCrawlingService {
   }
 
   private readonly category = {
-    POLITICS: '정치',
+    ECONOMICS: '경제',
     WORLD: '세계',
     IT: 'IT/과학',
   };
@@ -20,7 +20,7 @@ export class NewsCrawlingService {
   // naver news API 이용해 뉴스 정보 얻어오기
   async getNewsLinks(stockName: string) {
     const encodedStockName = encodeURI(stockName);
-    const newsUrl = `${process.env.NAVER_NEWS_URL}?query=${encodedStockName}&display=5&sort=sim`;
+    const newsUrl = `${process.env.NAVER_NEWS_URL}?query=${encodedStockName}&display=8&sort=sim`;
     try {
       const res: NewsInfoDto = await axios(newsUrl, {
         method: 'GET',
@@ -44,34 +44,47 @@ export class NewsCrawlingService {
 
   // 얻어온 뉴스 정보들 중 naver news에 기사가 있는 사이트에서 제목, 본문, 생성 날짜등을 크롤링해오기
   async crawling(stock: string, news: NewsItemDto[]) {
+    const crawledNews = await Promise.all(
+      news.map(async (n) => {
+        const url = decodeURI(n.link);
+        return await axios(url, {
+          method: 'GET',
+          headers: {
+            'User-Agent':
+              'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
+            'Accept-Language': 'ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7',
+          },
+        }).then(async (r) => {
+          const htmlString = await r.data;
+          const $ = cheerio.load(htmlString);
+
+          const category = $(
+            'li.Nlist_item._LNB_ITEM.is_active .Nitem_link_menu',
+          ).text();
+          const date = $('span._ARTICLE_DATE_TIME').attr('data-date-time');
+          const title = $('#title_area').text();
+          const content = $('#dic_area').text();
+
+
+          return {
+            category: category,
+            date: date,
+            title: title,
+            content: content,
+            url: url,
+          };
+        });
+      }),
+    );
     return {
       stockName: stock,
-      news: await Promise.all(
-        news.map(async (n) => {
-          const url = decodeURI(n.link);
-          return await axios(url, {
-            method: 'GET',
-            headers: {
-              'User-Agent':
-                'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3',
-              'Accept-Language': 'ko-KR,ko;q=0.9,en-US;q=0.8,en;q=0.7',
-            },
-          }).then(async (r) => {
-            const htmlString = await r.data;
-            const $ = cheerio.load(htmlString);
-
-            const date = $('span._ARTICLE_DATE_TIME').attr('data-date-time');
-            const title = $('#title_area').text();
-            const content = $('#dic_area').text();
-            return {
-              date: date,
-              title: title,
-              content: content,
-              url: url,
-            };
-          });
-        }),
-      ),
+      news: crawledNews.filter((n) => {
+        return (
+          n.category === this.category.ECONOMICS ||
+          n.category === this.category.IT ||
+          n.category === this.category.WORLD
+        );
+      }),
     } as CrawlingDataDto;
   }
 }

--- a/packages/backend/src/news/newsCrawling.service.ts
+++ b/packages/backend/src/news/newsCrawling.service.ts
@@ -11,6 +11,12 @@ export class NewsCrawlingService {
   constructor(@Inject('winston') private readonly logger: Logger) {
   }
 
+  private readonly category = {
+    POLITICS: '정치',
+    WORLD: '세계',
+    IT: 'IT/과학',
+  };
+
   // naver news API 이용해 뉴스 정보 얻어오기
   async getNewsLinks(stockName: string) {
     const encodedStockName = encodeURI(stockName);


### PR DESCRIPTION
close #53 

## ✅ 작업 내용
- 크롤링 시 기사 카테고리 필터링 작업 추가
- [크롤링시 뉴스 카테고리 필터링 기능 추가하기 개발일지](https://github.com/boostcampwm-2024/refactor-web40-juchumjuchum/wiki/%ED%81%AC%EB%A1%A4%EB%A7%81%EC%8B%9C-%EB%89%B4%EC%8A%A4-%EC%B9%B4%ED%85%8C%EA%B3%A0%EB%A6%AC-%ED%95%84%ED%84%B0%EB%A7%81-%EA%B8%B0%EB%8A%A5-%EC%B6%94%EA%B0%80%ED%95%98%EA%B8%B0)
## 📸 스크린샷(FE만)

## 📌 이슈 사항

## 🟢 완료 조건
- 세계/경제/IT/과학 분야의 기사만 크롤링해오기 

## ✍ 궁금한 점

## 😎 체크 사항

- [ ] label 설정 확인
- [ ] 브랜치 방향 확인
