### PR TITLE
클로바 응답 검증 로직 개선

### DIFF
--- a/packages/backend/src/news/StockNewsOrchestrationService.ts
+++ b/packages/backend/src/news/StockNewsOrchestrationService.ts
@@ -31,6 +31,7 @@ export class StockNewsOrchestrationService {
   private readonly MAX_RETRIES = 3;
   private readonly INITIAL_RETRY_DELAY = 60000;  // 60초
   private readonly PROCESS_DELAY = 3000;  // 주식 처리 사이 대기 시간 (3초)
+  private readonly INPUT_TOKEN_LIMIT = 7600;  // 개별 요청당 토큰 수 제한
   
   private getRetryDelay(retryCount: number): number {
     return this.INITIAL_RETRY_DELAY;
@@ -60,13 +61,12 @@ export class StockNewsOrchestrationService {
       let tokenLength =
         await this.newsSummaryService.calculateToken(stockNewsData);
 
-      while (tokenLength > 7600) {
+      while (tokenLength > this.INPUT_TOKEN_LIMIT) {
         this.logger.warn('Token length is too long. Reducing news data');
         stockNewsData.news.pop();
         tokenLength =
           await this.newsSummaryService.calculateToken(stockNewsData);
       }
-
       this.logger.info(`final token length: ${tokenLength}`);
 
       const rawSummarizedData = await this.newsSummaryService.summarizeNews(stockNewsData);

--- a/packages/backend/src/news/newsSummary.service.spec.ts
+++ b/packages/backend/src/news/newsSummary.service.spec.ts
@@ -1,0 +1,213 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { Logger } from 'winston';
+import { NewsSummaryService } from './newsSummary.service';
+import axios from 'axios';
+import { CrawlingDataDto } from './dto/crawlingData.dto';
+import { CreateStockNewsDto } from './dto/stockNews.dto';
+
+jest.mock('axios');
+const mockAxios = axios as jest.Mocked<typeof axios>;
+
+describe('NewsSummaryService', () => {
+  let mockLogger: Logger;
+  let newsSummaryService: NewsSummaryService;
+
+  beforeEach(async () => {
+    mockLogger = {
+      error: jest.fn(),
+      info: jest.fn(),
+    } as unknown as Logger;
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        NewsSummaryService,
+        {
+          provide: 'winston',
+          useValue: mockLogger,
+        },
+      ],
+    }).compile();
+
+    newsSummaryService = module.get<NewsSummaryService>(NewsSummaryService);
+  });
+
+  // 클로바 뉴스 요약 응답 예시 데이터 생성 함수
+  const createMockClovaResponse = (content: string) => ({
+    data: {
+      result: {
+        message: {
+          role: 'assistant',
+          content: content,
+        },
+      },
+    },
+  });
+
+  // 크롤링 데이터 예시
+  const mockCrwalingData: CrawlingDataDto = {
+    stockName: '삼성전자',
+    news: [
+      {
+        date: '2025.02.04',
+        title: '삼성전자 실적 발표',
+        content: '삼성전자가 좋은 실적을 발표했습니다.',
+        url: 'http://example1.com',
+      },
+    ],
+  };
+
+  describe('클로바 뉴스 요약 성공', () => {
+    test('클로바 뉴스 요약이 정상적으로 완료되면 정해진 형식의 데이터를 반환한다', async () => {
+      // given
+      const textContent = JSON.stringify({
+        stock_id: '005930',
+        stock_name: '삼성전자',
+        link: 'http://example1.com',
+        title: '삼성전자 실적 호조',
+        summary: '실적이 좋습니다',
+        positive_content: '긍정적입니다',
+        negative_content: '해당사항 없음',
+      });
+      const mockClovaResponse = createMockClovaResponse(textContent);
+      mockAxios.post.mockResolvedValue(mockClovaResponse);
+
+      // when
+      const result = await newsSummaryService.summarizeNews(mockCrwalingData);
+
+      // then
+      expect(result).toBeInstanceOf(CreateStockNewsDto);
+      expect(result).toEqual({
+        stock_id: '005930',
+        stock_name: '삼성전자',
+        link: 'http://example1.com',
+        title: '삼성전자 실적 호조',
+        summary: '실적이 좋습니다',
+        positive_content: '긍정적입니다',
+        negative_content: '해당사항 없음',
+      });
+    });
+
+    test.each([
+      [
+        'stockId',
+        {
+          stockId: '005930',
+          stock_name: '삼성전자',
+          link: 'http://example1.com',
+          title: '삼성전자 실적 호조',
+          summary: '실적이 좋습니다',
+          positive_content: '긍정적입니다',
+          negative_content: '해당사항 없음',
+        },
+      ],
+      [
+        'stockName',
+        {
+          stock_id: '005930',
+          stockName: '삼성전자',
+          link: 'http://example1.com',
+          title: '삼성전자 실적 호조',
+          summary: '실적이 좋습니다',
+          positive_content: '긍정적입니다',
+          negative_content: '해당사항 없음',
+        },
+      ],
+    ])(
+      '클로바 뉴스 요약에 %s 필드 key값이 있어도 정해진 형식의 데이터를 반환한다',
+      async (_, responseContent) => {
+        // given
+        const textContent = JSON.stringify(responseContent);
+        const mockClovaResponse = createMockClovaResponse(textContent);
+        mockAxios.post.mockResolvedValue(mockClovaResponse);
+
+        // when
+        const result = await newsSummaryService.summarizeNews(mockCrwalingData);
+
+        // then
+        expect(result).toBeInstanceOf(CreateStockNewsDto);
+        expect(result).toEqual({
+          stock_id: '005930',
+          stock_name: '삼성전자',
+          link: 'http://example1.com',
+          title: '삼성전자 실적 호조',
+          summary: '실적이 좋습니다',
+          positive_content: '긍정적입니다',
+          negative_content: '해당사항 없음',
+        });
+      },
+    );
+  });
+
+  describe('클로바 뉴스 요약 실패', () => {
+    // 클로바 응답 content 예시
+    const contentExample = {
+      stock_id: '005930',
+      stock_name: '삼성전자',
+      link: 'http://example1.com',
+      title: '삼성전자 실적 호조',
+      summary: '실적이 좋습니다',
+      positive_content: '긍정적입니다',
+      negative_content: '해당사항 없음',
+    };
+
+    test.each([
+      ['stock_id', { ...contentExample, stock_id: undefined }],
+      ['stock_name', { ...contentExample, stock_name: undefined }],
+      ['link', { ...contentExample, link: undefined }],
+      ['title', { ...contentExample, title: undefined }],
+      ['summary', { ...contentExample, summary: undefined }],
+      ['positive_content', { ...contentExample, positive_content: undefined }],
+      ['negative_content', { ...contentExample, negative_content: undefined }],
+    ])(
+      '클로바 뉴스 요약의 필수 필드 중 %s 가 없는 경우 null을 반환한다',
+      async (_, responseContent) => {
+        // given
+        const textContent = JSON.stringify(responseContent);
+        const mockClovaResponse = createMockClovaResponse(textContent);
+        mockAxios.post.mockResolvedValue(mockClovaResponse);
+
+        // when
+        const result = await newsSummaryService.summarizeNews(mockCrwalingData);
+
+        // then
+        expect(result).toBeNull();
+        expect(mockLogger.error).toHaveBeenCalled();
+      },
+    );
+
+    test('클로바 뉴스 요약 형태가 JSON이 아닌 경우 null을 반환한다', async () => {
+      // given
+      const mockClovaResponse = createMockClovaResponse(
+        '종목: 삼성전자, 제목: 실적 발표, 내용: 좋은 실적',
+      );
+      mockAxios.post.mockResolvedValue(mockClovaResponse);
+
+      // when
+      const result = await newsSummaryService.summarizeNews(mockCrwalingData);
+
+      // then
+      expect(result).toBeNull();
+      expect(mockLogger.error).toHaveBeenCalled();
+    });
+  });
+
+  describe('클로바 토큰 계산', () => {
+    test('클로바 토큰 계산이 정상적으로 완료되면 토큰 개수를 반환한다', async () => {
+      // given
+      const mockClovaTokenResponse = {
+        data: {
+          result: {
+            messages: [{ count: 687 }, { count: 5000 }],
+          },
+        },
+      };
+      mockAxios.post.mockResolvedValue(mockClovaTokenResponse);
+
+      // when
+      const result = await newsSummaryService.calculateToken(mockCrwalingData);
+
+      // then
+      expect(result).toBe(5687); // 687 + 5000
+    });
+  });
+});

--- a/packages/backend/src/news/newsSummary.service.ts
+++ b/packages/backend/src/news/newsSummary.service.ts
@@ -190,9 +190,23 @@ export class NewsSummaryService {
       const parsedContent = JSON.parse(content);
       const fixedContent = this.fixFieldNames(parsedContent);
 
-      if (!('stock_id' in fixedContent) || !('stock_name' in fixedContent)) {
+      const requiredFields = [
+        'stock_id',
+        'stock_name',
+        'link',
+        'title',
+        'summary',
+        'positive_content',
+        'negative_content',
+      ];
+
+      const missingFields = requiredFields.filter(
+        (field) => !(field in fixedContent),
+      );
+
+      if (missingFields.length > 0) {
         this.logger.error(
-          'Response is missing required fields: stock_id, stock_name',
+          `Clova Response is missing required fields: ${missingFields.join(', ')}`,
         );
         return null;
       }

--- a/packages/backend/src/news/newsSummary.service.ts
+++ b/packages/backend/src/news/newsSummary.service.ts
@@ -189,9 +189,11 @@ export class NewsSummaryService {
 
       const parsedContent = JSON.parse(content);
       const fixedContent = this.fixFieldNames(parsedContent);
-    
+
       if (!('stock_id' in fixedContent) || !('stock_name' in fixedContent)) {
-        this.logger.error('Response is missing required fields: stock_id, stock_name');
+        this.logger.error(
+          'Response is missing required fields: stock_id, stock_name',
+        );
         return null;
       }
 
@@ -204,8 +206,17 @@ export class NewsSummaryService {
 
   private fixFieldNames(content: any) {
     const fieldMappings: Record<string, string> = {
-      'stockId': 'stock_id',
-      'stockName': 'stock_name',
+      stockId: 'stock_id',
+      StockId: 'stock_id',
+      StockName: 'stock_name',
+      stockName: 'stock_name',
+      Link: 'link',
+      Title: 'title',
+      Summary: 'summary',
+      PositiveContent: 'positive_content',
+      positiveContent: 'positive_content',
+      NegativeContent: 'negative_content',
+      negativeContent: 'negative_content',
     };
 
     return Object.keys(content).reduce((acc: any, key: string) => {


### PR DESCRIPTION
- close #54 

## ✅ 작업 내용

### 클로바 뉴스 요약 응답 검증 로직 개선

- class-validator 와 class-transformer 라이브러리를 활용했습니다.
- plainToInstance()를 이용하여 CreateStockNewsDto의 인스턴스로 만들고, validateOrReejct()를 이용하여 필수 필드 key값이 없는 경우 에러를 발생시키도록 했습니다. 

```ts
  private async validateClovaResponse(response: any) {
    try {
      const content = response.data.result.message.content;
      this.logger.info(`Summarized news: ${content}`);

      const parsedContent = JSON.parse(content);
      const fixedContent = this.fixFieldNames(parsedContent);

      const summarizedNews = plainToInstance(CreateStockNewsDto, fixedContent);
      await validateOrReject(summarizedNews);

      return summarizedNews;
    } catch (error) {
      if (Array.isArray(error)) {
        this.logger.error(
          `Wrong field format from clova response: ${JSON.stringify(error, null, 2)}`,
        );
      } else {
        this.logger.error('Failed to parse clova response', error);
      }
      return null;
    }
  }
```


### NewsSummaryService 테스트 코드 작성

- 뉴스 요약 성공, 뉴스 요약 실패, 토큰 계산에 대한 테스트 코드를 추가했습니다.

#### 결과
![newsSummaryTest](https://github.com/user-attachments/assets/b51e3463-d7e1-41fa-8e45-7e1686e768b9)

#### 커버리지
![newsSummaryTest - 커버리지](https://github.com/user-attachments/assets/54aea3c9-3418-4a3f-84b8-507f2da6055a)


### 잘못된 응답 형식 실제 테스트

- 프롬프트를 변경하여 잘못된 응답 형식으로 오도록 했습니다.
    - positive_content 대신 positivie_contents 로 오도록 변경
    - negative_content 대신 negative_contents 로 오도록 변경

- 셀트리온 단일 종목에 대해서 테스트를 진행했고 try-catch에서 정상적으로 잡히는 것을 확인할 수 있었습니다.

![테스트용 응답 형식 에러 1](https://github.com/user-attachments/assets/af57cca8-48c0-4214-9b26-17ade32a7101)


## [개발일지](https://equinox-street-dc7.notion.site/250211-197391ecf7be802ea422df9bff79098f?pvs=4)

## 📸 스크린샷(FE만)

## 📌 이슈 사항



## 🟢 완료 조건

## ✍ 궁금한 점

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
