### PR TITLE
NewsSummaryService 커스텀 에러 구현

### DIFF
--- a/packages/backend/src/news/StockNewsOrchestrationService.ts
+++ b/packages/backend/src/news/StockNewsOrchestrationService.ts
@@ -4,6 +4,7 @@ import { NewsCrawlingService } from '@/news/newsCrawling.service';
 import { NewsSummaryService } from '@/news/newsSummary.service';
 import { StockNewsRepository } from '@/news/stockNews.repository';
 import { Cron } from '@nestjs/schedule';
+import { formatErrorMessage } from './error/formatErrorMessage';
 
 @Injectable()
 export class StockNewsOrchestrationService {
@@ -72,10 +73,6 @@ export class StockNewsOrchestrationService {
       this.logger.info('rawSummarizedData:');
       console.log(rawSummarizedData);
 
-      if (!rawSummarizedData) {
-        throw new Error(`Failed to summarize news for ${stock.name}`);
-      }
-
       const finalSummarizedData = {
         ...rawSummarizedData,
         stock_id: stock.id,
@@ -87,7 +84,8 @@ export class StockNewsOrchestrationService {
       return { success: true, stock };
       
     } catch (error) {
-      this.logger.error(`Error processing news for ${stock.name}:`, error);
+      const errorMessage = formatErrorMessage(error, stock.name);
+      this.logger.error(errorMessage);
       
       if (retryCount < this.MAX_RETRIES) {
         const delay = this.getRetryDelay();

--- a/packages/backend/src/news/error/formatErrorMessage.ts
+++ b/packages/backend/src/news/error/formatErrorMessage.ts
@@ -1,0 +1,9 @@
+import { NewsSummaryException } from './newsSummary.error';
+
+export const formatErrorMessage = (error: unknown, stockName: string) => {
+  if (error instanceof NewsSummaryException) {
+    return `Error processing news for ${stockName}: ${error.message}`;
+  }
+
+  return `Unknown Error processing news for ${stockName}: ${String(error)}`;
+};

--- a/packages/backend/src/news/error/newsSummary.error.ts
+++ b/packages/backend/src/news/error/newsSummary.error.ts
@@ -1,0 +1,35 @@
+export class NewsSummaryException extends Error {
+  private readonly error?: unknown;
+  constructor(message: string, error?: unknown) {
+    super(message);
+    this.error = error;
+  }
+
+  getError() {
+    return this.error;
+  }
+}
+
+export class SummaryAPIException extends NewsSummaryException {
+  constructor(message: string, error?: unknown) {
+    super(`Failed to Summarize News: ${message}`, error);
+  }
+}
+
+export class SummaryFieldException extends NewsSummaryException {
+  constructor(message: string, error?: unknown) {
+    super(`Wrong field format from clova response: ${message}`, error);
+  }
+}
+
+export class SummaryJsonException extends NewsSummaryException {
+  constructor(message: string, error?: unknown) {
+    super(`Failed to parse clova response: ${message}`, error);
+  }
+}
+
+export class TokenAPIException extends NewsSummaryException {
+  constructor(message: string, error?: unknown) {
+    super(`Failed to Calculate Token: ${message}`, error);
+  }
+}

--- a/packages/backend/src/news/newsSummary.service.spec.ts
+++ b/packages/backend/src/news/newsSummary.service.spec.ts
@@ -48,6 +48,7 @@ describe('NewsSummaryService', () => {
     stockName: '삼성전자',
     news: [
       {
+        category: '경제',
         date: '2025.02.04',
         title: '삼성전자 실적 발표',
         content: '삼성전자가 좋은 실적을 발표했습니다.',

--- a/packages/backend/src/news/newsSummary.service.ts
+++ b/packages/backend/src/news/newsSummary.service.ts
@@ -213,21 +213,18 @@ export class NewsSummaryService {
 
   private fixFieldNames(content: any) {
     const fieldMappings: Record<string, string> = {
-      stockId: 'stock_id',
-      StockId: 'stock_id',
-      StockName: 'stock_name',
-      stockName: 'stock_name',
-      Link: 'link',
-      Title: 'title',
-      Summary: 'summary',
-      PositiveContent: 'positive_content',
-      positiveContent: 'positive_content',
-      NegativeContent: 'negative_content',
-      negativeContent: 'negative_content',
+      stockid: 'stock_id',
+      stockname: 'stock_name',
+      link: 'link',
+      title: 'title',
+      summary: 'summary',
+      positivecontent: 'positive_content',
+      negativecontent: 'negative_content',
     };
 
     return Object.keys(content).reduce((acc: any, key: string) => {
-      const fixedKey = fieldMappings[key] || key;
+      const lowKey = key.toLowerCase();
+      const fixedKey = fieldMappings[lowKey] || key;
       acc[fixedKey] = content[key];
       return acc;
     }, {});

--- a/packages/backend/src/news/newsSummary.service.ts
+++ b/packages/backend/src/news/newsSummary.service.ts
@@ -5,6 +5,12 @@ import { CreateStockNewsDto } from './dto/stockNews.dto';
 import { CrawlingDataDto } from '@/news/dto/crawlingData.dto';
 import { plainToInstance } from 'class-transformer';
 import { validateOrReject } from 'class-validator';
+import {
+  SummaryFieldException,
+  SummaryJsonException,
+  SummaryAPIException,
+  TokenAPIException,
+} from './error/newsSummary.error';
 
 @Injectable()
 export class NewsSummaryService {
@@ -34,12 +40,12 @@ export class NewsSummaryService {
       return summarizedNews;
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        this.logger.error(
-          `Failed to summarize news: status=${error.response?.data?.status?.code}, data=${error.response?.data?.status?.message}`,
+        throw new SummaryAPIException(
+          `${JSON.stringify(error.response?.data ?? error.message)}`,
+          error,
         );
-      } else {
-        this.logger.error('Unknown Error', error);
       }
+      throw error;
     }
   }
 
@@ -63,12 +69,12 @@ export class NewsSummaryService {
       return totalToken;
     } catch (error) {
       if (axios.isAxiosError(error)) {
-        this.logger.error(
-          `Failed to calculate token: status=${error.response?.data?.status?.code}, data=${error.response?.data?.status?.message}`,
+        throw new TokenAPIException(
+          `${JSON.stringify(error.response?.data ?? error.message)}`,
+          error,
         );
-      } else {
-        this.logger.error('Unknown Error', error);
       }
+      throw error;
     }
   }
 
@@ -186,13 +192,12 @@ export class NewsSummaryService {
       return summarizedNews;
     } catch (error) {
       if (Array.isArray(error)) {
-        this.logger.error(
-          `Wrong field format from clova response: ${JSON.stringify(error, null, 2)}`,
+        throw new SummaryFieldException(
+          `${JSON.stringify(error, null, 2)}`,
+          error,
         );
-      } else {
-        this.logger.error('Failed to parse clova response', error);
       }
-      return null;
+      throw new SummaryJsonException('Invalid JSON', error);
     }
   }
 

--- a/packages/backend/src/news/newsSummary.service.ts
+++ b/packages/backend/src/news/newsSummary.service.ts
@@ -59,10 +59,20 @@ export class NewsSummaryService {
         },
       );
 
-      const messages = clovaTokenResponse.data.result.messages;
-      const totalToken = messages.reduce((acc: number, message: any) => {
-        return acc + message.count;
-      }, 0);
+      const messages = clovaTokenResponse.data.result?.messages;
+      if (!messages || !Array.isArray(messages)) {
+        throw new TokenAPIException('Invalid clova token response format');
+      }
+
+      const totalToken = messages.reduce(
+        (acc: number, message: any): number => {
+          if (typeof message.count !== 'number') {
+            throw new TokenAPIException('Invalid clova token count format');
+          }
+          return acc + message.count;
+        },
+        0,
+      );
 
       this.logger.info(`token length: ${totalToken}`);
 


### PR DESCRIPTION
- close #66 

## ✅ 작업 내용

- NewsSummaryService에서 뉴스 요약에 실패하면 null을 반환하는 것이 아닌 커스텀 Exception을 던지는 형태로 변경했습니다.
- NewsSummaryException 커스텀 에러 클래스를 만들고, 각 상황별 하위 Exception을 만들었습니다.
- StockNewsOrchestrationService에서 변경된 구조에 따라 에러 로깅을 잘 할 수 있게 수정했습니다.
- NewsSummaryService 테스트 코드를 변경된 구조에 따라 수정했습니다.
    - 또한, API 에러가 발생한 경우에 대한 케이스도 추가했습니다.

### 테스트 결과

![테스트 결과](https://github.com/user-attachments/assets/87dd8838-1cc3-4863-9d1f-9499c6fb7d5a)


## [개발 일지](https://equinox-street-dc7.notion.site/250212-198391ecf7be80b49400ea3eec4c3b24?pvs=4)

## 📸 스크린샷(FE만)

## 📌 이슈 사항

## 🟢 완료 조건

## ✍ 궁금한 점

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
