### PR TITLE
특정 종목만 주식 상세 정보가 렌더링 되지 않는 이슈 해결

### DIFF
--- a/packages/frontend/src/pages/stock-detail/StockMetricsPanel.tsx
+++ b/packages/frontend/src/pages/stock-detail/StockMetricsPanel.tsx
@@ -63,7 +63,7 @@ export const StockMetricsPanel = ({
 
   return (
     <article className="flex flex-1 flex-col gap-10 rounded-md bg-white p-6 shadow">
-      {!price || !change || !volume ? (
+      {price === 0 && change === 0 && volume === 0 ? (
         <section className="grid w-9/12 lg:grid-cols-2 lg:grid-rows-2">
           {Array.from({ length: 4 }, () => (
             <Lottie


### PR DESCRIPTION
- close #73 

## ✅ 작업 내용

- 특정 종목에서만 주식 상세 정보가 렌더링 되지 않는 이슈를 해결했습니다.
- StockMetricsPanel 컴포넌트에서 상태 자체는 잘 업데이트 하는데, 렌더링 조건에 문제가 있었습니다.
- `realTimeData`의 초기값이 {price: 0, change: 0, volume: 0} 이기 때문에, 이 조건을 모두 만족하는 경우에만 skeleton을 보여주도록 변경했습니다.

### AS-IS

```tsx
return (
    <article className="flex flex-1 flex-col gap-10 rounded-md bg-white p-6 shadow">
      {!price || !change || !volume ? (
        <section className="grid w-9/12 lg:grid-cols-2 lg:grid-rows-2">
```

### TO-BE
```tsx
return (
    <article className="flex flex-1 flex-col gap-10 rounded-md bg-white p-6 shadow">
      {price === 0 && change === 0 && volume === 0 ? (
        <section className="grid w-9/12 lg:grid-cols-2 lg:grid-rows-2">
```

## [개발일지](https://equinox-street-dc7.notion.site/250214-19a391ecf7be80a1a5e5d9f22ba46872?pvs=4)



## 📸 스크린샷(FE만)

![렌더링 문제 해결 - 화면](https://github.com/user-attachments/assets/d20da437-38a8-416e-9b64-9cc0b6a06bc1)


## 📌 이슈 사항

## 🟢 완료 조건

## ✍ 궁금한 점

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
