### PR TITLE
Feat #75 add date filtering

### DIFF
--- a/packages/backend/src/news/newsCrawling.service.ts
+++ b/packages/backend/src/news/newsCrawling.service.ts
@@ -68,15 +68,10 @@ export class NewsCrawlingService {
           const category = $(
             'li.Nlist_item._LNB_ITEM.is_active .Nitem_link_menu',
           ).text();
-          if (
-            category !== this.category.ECONOMICS &&
-            category !== this.category.IT &&
-            category !== this.category.WORLD
-          ) {
+          if (this.isAvailableCategory(category)) {
             return null;
           }
           const date = $('span._ARTICLE_DATE_TIME').attr('data-date-time');
-          console.log(`date : ${date} , Date.parser : ${Date.parse(date!)}`);
 
           const title = $('#title_area').text();
           const content = $('#dic_area').text();
@@ -95,6 +90,12 @@ export class NewsCrawlingService {
       stockName: stock,
       news: crawledNews.filter((n) => n !== null),
     } as CrawlingDataDto;
+  }
+
+  isAvailableCategory(category: string) {
+    return category !== this.category.ECONOMICS &&
+      category !== this.category.IT &&
+      category !== this.category.WORLD;
   }
 
   isSameDate(date1: Date, date2: Date) {

--- a/packages/backend/src/news/newsCrawling.service.ts
+++ b/packages/backend/src/news/newsCrawling.service.ts
@@ -76,6 +76,8 @@ export class NewsCrawlingService {
             return null;
           }
           const date = $('span._ARTICLE_DATE_TIME').attr('data-date-time');
+          console.log(`date : ${date} , Date.parser : ${Date.parse(date!)}`);
+
           const title = $('#title_area').text();
           const content = $('#dic_area').text();
 
@@ -93,5 +95,13 @@ export class NewsCrawlingService {
       stockName: stock,
       news: crawledNews.filter((n) => n !== null),
     } as CrawlingDataDto;
+  }
+
+  isSameDate(date1: Date, date2: Date) {
+    return (
+      date1.getFullYear() === date2.getFullYear() &&
+      date1.getMonth() === date2.getMonth() &&
+      date1.getDate() === date2.getDate()
+    );
   }
 }

--- a/packages/backend/src/news/newsCrawling.service.ts
+++ b/packages/backend/src/news/newsCrawling.service.ts
@@ -93,16 +93,26 @@ export class NewsCrawlingService {
   }
 
   isAvailableCategory(category: string) {
-    return category !== this.category.ECONOMICS &&
+    return (
+      category !== this.category.ECONOMICS &&
       category !== this.category.IT &&
-      category !== this.category.WORLD;
+      category !== this.category.WORLD
+    );
   }
 
-  isSameDate(date1: Date, date2: Date) {
+  changeToKorTime() {
+    const now = new Date();
+    const utc = now.getTime() + now.getTimezoneOffset() * 60000;
+    return new Date(utc + 9 * 60 * 60000);
+  }
+
+  isSameDate(date: string, now: Date) {
+    const parsedDate = new Date(date);
+
     return (
-      date1.getFullYear() === date2.getFullYear() &&
-      date1.getMonth() === date2.getMonth() &&
-      date1.getDate() === date2.getDate()
+      parsedDate.getFullYear() === now.getFullYear() &&
+      parsedDate.getMonth() === now.getMonth() &&
+      parsedDate.getDate() === now.getDate()
     );
   }
 }

--- a/packages/backend/src/news/newsCrawling.service.ts
+++ b/packages/backend/src/news/newsCrawling.service.ts
@@ -10,13 +10,13 @@ import { CrawlingDataDto } from '@/news/dto/crawlingData.dto';
 export class NewsCrawlingService {
   private readonly MAX_NEWS_COUNT = 5;
 
-  constructor(@Inject('winston') private readonly logger: Logger) {
-  }
+  constructor(@Inject('winston') private readonly logger: Logger) {}
 
   private readonly category = {
     ECONOMICS: '경제',
     WORLD: '세계',
     IT: 'IT/과학',
+    POLITICS: '정치',
   };
 
   // naver news API 이용해 뉴스 정보 얻어오기
@@ -104,7 +104,7 @@ export class NewsCrawlingService {
     );
   }
 
-  changeToKorTime() {
+  getCurrentKorTime() {
     const now = new Date();
     const utc = now.getTime() + now.getTimezoneOffset() * 60000;
     return new Date(utc + 9 * 60 * 60000);
@@ -112,7 +112,7 @@ export class NewsCrawlingService {
 
   isSameDate(date: string) {
     const parsedDate = new Date(date);
-    const now = this.changeToKorTime();
+    const now = this.getCurrentKorTime();
     return (
       parsedDate.getFullYear() === now.getFullYear() &&
       parsedDate.getMonth() === now.getMonth() &&

--- a/packages/backend/src/news/newsCrawling.service.ts
+++ b/packages/backend/src/news/newsCrawling.service.ts
@@ -71,7 +71,11 @@ export class NewsCrawlingService {
           if (this.isAvailableCategory(category)) {
             return null;
           }
+
           const date = $('span._ARTICLE_DATE_TIME').attr('data-date-time');
+          if (!this.isSameDate(date!)) {
+            return null;
+          }
 
           const title = $('#title_area').text();
           const content = $('#dic_area').text();
@@ -106,9 +110,9 @@ export class NewsCrawlingService {
     return new Date(utc + 9 * 60 * 60000);
   }
 
-  isSameDate(date: string, now: Date) {
+  isSameDate(date: string) {
     const parsedDate = new Date(date);
-
+    const now = this.changeToKorTime();
     return (
       parsedDate.getFullYear() === now.getFullYear() &&
       parsedDate.getMonth() === now.getMonth() &&


### PR DESCRIPTION
close #75

## ✅ 작업 내용
- 크롤링에 날짜 필터링 적용
- [날짜 필터링 적용하기](https://github.com/boostcampwm-2024/refactor-web40-juchumjuchum/wiki/%ED%81%AC%EB%A1%A4%EB%A7%81%EC%97%90-%EB%82%A0%EC%A7%9C-%ED%95%84%ED%84%B0%EB%A7%81%EC%9D%84-%EC%A0%81%EC%9A%A9%ED%95%98%EA%B8%B0)

## 📸 스크린샷(FE만)

## 📌 이슈 사항

## 🟢 완료 조건

## ✍ 궁금한 점

## 😎 체크 사항

- [ ] label 설정 확인
- [ ] 브랜치 방향 확인
