### PR TITLE
서버가 죽는 이유를 파악하기 위한 커스텀 로거 구현

### DIFF
--- a/packages/backend/src/app.module.ts
+++ b/packages/backend/src/app.module.ts
@@ -15,6 +15,7 @@ import {
 import { StockModule } from '@/stock/stock.module';
 import { UserModule } from '@/user/user.module';
 import { StockNewsModule } from '@/news/stockNews.module';
+import { CustomLoggerModule } from './common/logger/customLogger.module';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { StockNewsModule } from '@/news/stockNews.module';
     ChatModule,
     SessionModule,
     StockNewsModule,
+    CustomLoggerModule,
   ],
   controllers: [],
   providers: [],

--- a/packages/backend/src/common/logger/connectionMonitor.service.ts
+++ b/packages/backend/src/common/logger/connectionMonitor.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@nestjs/common';
+import { DataSource } from 'typeorm';
+
+@Injectable()
+export class ConnectionMonitorService {
+  constructor(private readonly datasource: DataSource) {}
+
+  getConnectionPoolInfo() {
+    const pool = (this.datasource.driver as any).pool;
+    if (!pool) {
+      return '';
+    }
+
+    const status = {
+      total: pool._allConnections.length,
+      free: pool._freeConnections.length,
+      pending: pool._connectionQueue.length,
+    };
+
+    return `[Connections]: ${JSON.stringify(status)}`;
+  }
+}

--- a/packages/backend/src/common/logger/customLogger.module.ts
+++ b/packages/backend/src/common/logger/customLogger.module.ts
@@ -1,0 +1,13 @@
+import { Global, Module } from '@nestjs/common';
+import { CustomLogger } from './customLogger';
+import { WinstonModule } from 'nest-winston';
+import { logger } from '@/configs/logger.config';
+import { ConnectionMonitorService } from './connectionMonitor.service';
+
+@Global()
+@Module({
+  imports: [WinstonModule.forRoot(logger)],
+  providers: [CustomLogger, ConnectionMonitorService],
+  exports: [CustomLogger],
+})
+export class CustomLoggerModule {}

--- a/packages/backend/src/common/logger/customLogger.ts
+++ b/packages/backend/src/common/logger/customLogger.ts
@@ -1,0 +1,30 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { ConnectionMonitorService } from './connectionMonitor.service';
+import { Logger } from 'winston';
+
+@Injectable()
+export class CustomLogger {
+  constructor(
+    private readonly connectionMonitorService: ConnectionMonitorService,
+    @Inject('winston') private readonly logger: Logger,
+  ) {}
+
+  log(level: string, message: string, context?: string) {
+    this.logger.log(level, message, {
+      context,
+      connectionInfo: this.connectionMonitorService.getConnectionPoolInfo(),
+    });
+  }
+
+  info(message: string, context?: string) {
+    this.log('info', message, context);
+  }
+
+  warn(message: string, context?: string) {
+    this.log('warn', message, context);
+  }
+
+  error(message: string, context: string) {
+    this.log('error', message, context);
+  }
+}

--- a/packages/backend/src/configs/logger.config.ts
+++ b/packages/backend/src/configs/logger.config.ts
@@ -3,9 +3,11 @@ import * as DailyRotateFile from 'winston-daily-rotate-file';
 
 const { combine, timestamp, printf } = format;
 
-const logFormat = printf(({ level, message, timestamp, context }) => {
-  return `[${timestamp}][${level}]${context ? `[${context}]` : ''}: ${message}`;
-});
+const logFormat = printf(
+  ({ level, message, timestamp, context, connectionInfo }) => {
+    return `[${timestamp}][${level}]${context ? `[${context}]` : ''}: ${message} ${connectionInfo ?? ''}`;
+  },
+);
 
 export const logger = createLogger({
   format: combine(timestamp({ format: 'YYYY-MM-DD HH:mm:ss.SSS' }), logFormat),
@@ -37,10 +39,7 @@ export const logger = createLogger({
 
     // Console transport 추가
     new transports.Console({
-      format: combine(
-        format.colorize(),
-        logFormat
-      )
+      format: combine(format.colorize(), logFormat),
     }),
   ],
 });

--- a/packages/backend/src/stock/stock.module.ts
+++ b/packages/backend/src/stock/stock.module.ts
@@ -25,6 +25,7 @@ import { StockDataService } from '@/stock/stockData.service';
 import { StockRepository } from '@/stock/repository/stock.repository';
 import { UserStockRepository } from '@/stock/repository/userStock.repository';
 import { UserStock } from './domain/userStock.entity';
+import { ConnectionMonitorService } from '@/common/logger/connectionMonitor.service';
 
 @Module({
   imports: [
@@ -55,6 +56,7 @@ import { UserStock } from './domain/userStock.entity';
     StockRateIndexService,
     StockRepository,
     UserStockRepository,
+    ConnectionMonitorService,
   ],
   exports: [StockService],
 })

--- a/packages/backend/src/stock/stock.service.spec.ts
+++ b/packages/backend/src/stock/stock.service.spec.ts
@@ -1,6 +1,5 @@
 import { plainToInstance } from 'class-transformer';
 import { instance, mock, verify, when } from 'ts-mockito';
-import { Logger } from 'winston';
 import { Stock } from './domain/stock.entity';
 import { StockService } from './stock.service';
 import {
@@ -11,10 +10,11 @@ import {
 import { User } from '@/user/domain/user.entity';
 import { StockRepository } from './repository/stock.repository';
 import { UserStockRepository } from './repository/userStock.repository';
+import { CustomLogger } from '@/common/logger/customLogger';
 
 describe('StockService 테스트', () => {
   // mocked classes
-  let mockLogger: Logger;
+  let mockLogger: CustomLogger;
   let mockStockRepository: StockRepository;
   let mockUserStockRepository: UserStockRepository;
 
@@ -24,7 +24,7 @@ describe('StockService 테스트', () => {
   beforeEach(() => {
     mockStockRepository = mock(StockRepository);
     mockUserStockRepository = mock(UserStockRepository);
-    mockLogger = mock(Logger);
+    mockLogger = mock(CustomLogger);
 
     stockService = new StockService(
       instance(mockStockRepository),

--- a/packages/backend/src/stock/stockData.service.ts
+++ b/packages/backend/src/stock/stockData.service.ts
@@ -22,6 +22,7 @@ import { NewDate } from '@/scraper/openapi/util/newDate.util';
 import { StockDataCache } from '@/stock/cache/stockData.cache';
 import { StockLiveData } from '@/stock/domain/stockLiveData.entity';
 import { getFormattedDate, isTodayWeekend } from '@/utils/date';
+import { CustomLogger } from '@/common/logger/customLogger';
 
 type StockData = {
   id: number;
@@ -38,11 +39,13 @@ type StockData = {
 @Injectable()
 export class StockDataService {
   protected readonly PAGE_SIZE = 100;
+  private readonly context = 'StockDataService';
 
   constructor(
     private readonly dataSource: DataSource,
     private readonly stockDataCache: StockDataCache,
     private readonly openapiPeriodData: OpenapiPeriodData,
+    private readonly customLogger: CustomLogger,
   ) {}
 
   async scrollChart(
@@ -86,6 +89,7 @@ export class StockDataService {
   }
 
   private async isStockExist(stockId: string, manager: EntityManager) {
+    this.customLogger.info(`check stock exist for stock: ${stockId}`, this.context);
     return await manager.exists(Stock, { where: { id: stockId } });
   }
 
@@ -94,6 +98,7 @@ export class StockDataService {
     stockId: string,
     lastStartTime?: string,
   ) {
+    this.customLogger.info(`get chart data for stock: ${stockId}`, this.context);
     const lastData = await this.findLastData(entity, stockId);
     const periodType = this.getPeriodType(entity);
     if (!periodType) throw new BadRequestException('period type not found');
@@ -126,6 +131,7 @@ export class StockDataService {
     entity: new () => StockData,
     stockId: string,
   ) {
+    this.customLogger.info(`renew chart data for stock: ${stockId}`, this.context);
     const liveData = await this.dataSource.manager.findOne(StockLiveData, {
       where: { stock: { id: stockId } },
     });
@@ -140,6 +146,7 @@ export class StockDataService {
     stockId: string,
     lastStartTime?: string,
   ) {
+    this.customLogger.info(`get chart data from db for stock: ${stockId}`, this.context);
     const queryBuilder = this.createQueryBuilder(
       entity,
       stockId,

--- a/packages/backend/src/stock/stockDetail.service.spec.ts
+++ b/packages/backend/src/stock/stockDetail.service.spec.ts
@@ -6,16 +6,16 @@ import {
   Repository,
   SelectQueryBuilder,
 } from 'typeorm';
-import { Logger } from 'winston';
 import { StockDetail } from './domain/stockDetail.entity';
 import { StockDetailService } from './stockDetail.service';
 import { Stock } from '@/stock/domain/stock.entity';
 import { StockDetailResponse } from '@/stock/dto/stockDetail.response';
+import { CustomLogger } from '@/common/logger/customLogger';
 
 describe('StockDetailService 테스트', () => {
   const stockId = '005930';
   let stockDetailService: StockDetailService;
-  let logger: Logger;
+  let customLoggerMock: CustomLogger;
   let dataSourceMock: DataSource;
   let managerMock: EntityManager;
   let repositoryMock: Repository<StockDetail>;
@@ -23,13 +23,13 @@ describe('StockDetailService 테스트', () => {
 
   beforeEach(() => {
     dataSourceMock = mock(DataSource);
-    logger = mock(Logger);
+    customLoggerMock = mock(CustomLogger);
     managerMock = mock(EntityManager);
     repositoryMock = mock(Repository);
     queryBuilderMock = mock(SelectQueryBuilder);
     stockDetailService = new StockDetailService(
       instance(dataSourceMock),
-      instance(logger),
+      instance(customLoggerMock),
     );
     when(dataSourceMock.transaction(anything())).thenCall(async (callback) => {
       return await callback(instance(managerMock));

--- a/packages/backend/src/stock/stockDetail.service.ts
+++ b/packages/backend/src/stock/stockDetail.service.ts
@@ -1,24 +1,27 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { DataSource } from 'typeorm';
-import { Logger } from 'winston';
 import { StockDetail } from './domain/stockDetail.entity';
 import { StockDetailResponse } from './dto/stockDetail.response';
+import { CustomLogger } from '@/common/logger/customLogger';
 
 @Injectable()
 export class StockDetailService {
+  private readonly context = 'StockDetailService';
+
   constructor(
     private readonly datasource: DataSource,
-    @Inject('winston') private readonly logger: Logger,
+    private readonly customLogger: CustomLogger,
   ) {}
 
   async getStockDetailByStockId(stockId: string): Promise<StockDetailResponse> {
     return await this.datasource.transaction(async (manager) => {
+      this.customLogger.info(`get stock detail by stockId: ${stockId}`, this.context);
       const isExists = await manager.existsBy(StockDetail, {
         stock: { id: stockId },
       });
 
       if (!isExists) {
-        this.logger.warn(`stock detail not found (stockId: ${stockId})`);
+        this.customLogger.warn(`stock detail not found for stock: ${stockId}`, this.context);
         throw new NotFoundException(
           `stock detail not found (stockId: ${stockId}`,
         );

--- a/packages/backend/src/stock/stockRateIndex.service.spec.ts
+++ b/packages/backend/src/stock/stockRateIndex.service.spec.ts
@@ -7,15 +7,16 @@ import { Stock } from './domain/stock.entity';
 import { StockLiveData } from './domain/stockLiveData.entity';
 import { StockIndexRateResponse } from './dto/stockIndexRate.response';
 import { StockRateIndexService } from './stockRateIndex.service';
+import { CustomLogger } from '@/common/logger/customLogger';
 
 describe('StockRateIndexService', () => {
   let stockRateIndexService: StockRateIndexService;
   let dataSource: Partial<DataSource>;
-  const logger: Logger = {
-    error: jest.fn(),
-    warn: jest.fn(),
+  const customLoggerMock = {
     info: jest.fn(),
-  } as unknown as Logger;
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as jest.Mocked<CustomLogger>;
 
   const createDataSourceMock = (managerMock: any): Partial<DataSource> => {
     return {
@@ -39,7 +40,7 @@ describe('StockRateIndexService', () => {
     dataSource = createDataSourceMock(managerMock);
     stockRateIndexService = new StockRateIndexService(
       dataSource as DataSource,
-      logger as Logger,
+      customLoggerMock,
     );
   });
 
@@ -60,7 +61,7 @@ describe('StockRateIndexService', () => {
     dataSource = createDataSourceMock(managerMock);
     stockRateIndexService = new StockRateIndexService(
       dataSource as DataSource,
-      logger as Logger,
+      customLoggerMock,
     );
 
     await expect(stockRateIndexService.getStockRateIndexDate()).rejects.toThrow(

--- a/packages/backend/src/stock/stockRateIndex.service.ts
+++ b/packages/backend/src/stock/stockRateIndex.service.ts
@@ -1,25 +1,28 @@
-import { Inject, Injectable, NotFoundException } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { DataSource } from 'typeorm';
-import { Logger } from 'winston';
 import { StockLiveData } from './domain/stockLiveData.entity';
 import { StockIndexRateResponse } from './dto/stockIndexRate.response';
 import { IndexRateGroupCode } from '@/scraper/openapi/type/openapiIndex.type';
+import { CustomLogger } from '@/common/logger/customLogger';
 
 @Injectable()
 export class StockRateIndexService {
+  private readonly context = 'StockRateIndexService';
+
   constructor(
     private readonly datasource: DataSource,
-    @Inject('winston') private readonly logger: Logger,
+    private readonly customLogger: CustomLogger,
   ) {}
 
   async getRateIndexData(groupCode: IndexRateGroupCode) {
+    this.customLogger.info(`get rate index data for group code: ${groupCode}`, this.context);
     const result = await this.datasource.manager.find(StockLiveData, {
       where: { stock: { groupCode } },
       relations: ['stock'],
     });
 
     if (!result.length) {
-      this.logger.warn(`Rate data not found for group code: ${groupCode}`);
+      this.customLogger.warn(`Rate data not found for group code: ${groupCode}`, this.context);
       throw new NotFoundException('Rate data not found');
     }
     return result;


### PR DESCRIPTION
- still in progress: #24 

## ✅ 작업 내용

- 서버가 죽는 이유를 파악하기 위해 커스텀 로거 클래스를 새로 만들었습니다.
- winston을 기반으로 mysql pool의 connection을 모니터링할 수 있게 해주었습니다.
- 현재는 Stock 디렉토리 밑에 있는 파일들에만 커스텀 로거가 적용된 상태입니다.

## 📸 스크린샷(FE만)

## 📌 이슈 사항

## 🟢 완료 조건

## ✍ 궁금한 점

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
