### PR TITLE
서버가 죽는 에러 해결 1차 시도

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,7 +3,7 @@
   "semi": true,
   "tabWidth": 2,
   "trailingComma": "all",
-  "printWidth": 80,
+  "printWidth": 100,
   "bracketSpacing": true,
   "endOfLine": "lf",
   "useTabs": false,

--- a/packages/backend/src/configs/typeormConfig.ts
+++ b/packages/backend/src/configs/typeormConfig.ts
@@ -1,6 +1,5 @@
 import { TypeOrmModuleOptions } from '@nestjs/typeorm';
 import * as dotenv from 'dotenv';
-import { CustomQueryLogger } from '@/configs/customQueryLogger';
 
 dotenv.config();
 
@@ -24,4 +23,7 @@ export const typeormDevelopConfig: TypeOrmModuleOptions = {
   entities: [__dirname + '/../**/*.entity.{js,ts}'],
   // logging: true,
   synchronize: true,
+  extra: {
+    connectionLimit: 30,
+  },
 };

--- a/packages/backend/src/scraper/openapi/api/openapiFluctuationData.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiFluctuationData.api.ts
@@ -1,40 +1,44 @@
-import { Inject, Injectable } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import { Cron } from '@nestjs/schedule';
 import { DataSource, EntityManager } from 'typeorm';
-import { Logger } from 'winston';
 import { OpenapiLiveData } from '@/scraper/openapi/api/openapiLiveData.api';
-import {
-  DECREASE_STOCK_QUERY,
-  INCREASE_STOCK_QUERY,
-} from '@/scraper/openapi/constants/query';
+import { DECREASE_STOCK_QUERY, INCREASE_STOCK_QUERY } from '@/scraper/openapi/constants/query';
 import { Json, OpenapiQueue } from '@/scraper/openapi/queue/openapi.queue';
 import { TR_IDS } from '@/scraper/openapi/type/openapiUtil.type';
 import { FluctuationRankStock } from '@/stock/domain/FluctuationRankStock.entity';
 import { Stock } from '@/stock/domain/stock.entity';
+import { CustomLogger } from '@/common/logger/customLogger';
 
 @Injectable()
 export class OpenapiFluctuationData {
-  private readonly fluctuationUrl =
-    '/uapi/domestic-stock/v1/ranking/fluctuation';
+  private readonly fluctuationUrl = '/uapi/domestic-stock/v1/ranking/fluctuation';
   private readonly liveUrl = '/uapi/domestic-stock/v1/quotations/inquire-price';
+  private readonly context = 'OpenapiFluctuationData';
+
   constructor(
     private readonly datasource: DataSource,
     private readonly openApiQueue: OpenapiQueue,
     private readonly openApiLive: OpenapiLiveData,
-    @Inject('winston') private readonly logger: Logger,
+    private readonly customLogger: CustomLogger,
   ) {
     setTimeout(() => this.getFluctuationRankStocks(), 1000);
   }
 
   @Cron('*/1 9-15 * * 1-5')
   async getFluctuationRankStocks() {
+    this.customLogger.info('Start getFluctuationRankStocks', this.context);
     await this.getFluctuationRankFromApi(true);
     await this.getFluctuationRankFromApi(false);
   }
 
   async getFluctuationRankFromApi(isRising: boolean) {
+    this.customLogger.info(`Get fluctuation rank stocks, isRising: ${isRising}`, this.context);
     const query = isRising ? INCREASE_STOCK_QUERY : DECREASE_STOCK_QUERY;
+
+    this.customLogger.info(`Delete fluctuation rank stocks`, this.context);
     await this.datasource.manager.delete(FluctuationRankStock, { isRising });
+
+    this.customLogger.info('Enqueue getFluctuationRankFromApi requests', this.context);
     this.openApiQueue.enqueue({
       url: this.fluctuationUrl,
       query,
@@ -44,8 +48,11 @@ export class OpenapiFluctuationData {
   }
 
   private getFluctuationRankStocksCallback(isRising: boolean) {
+    this.customLogger.info(`Fluctuation rank stocks Callback, isRising: ${isRising}`, this.context);
     return async (data: Json) => {
       const save = this.convertToFluctuationRankStock(data, isRising);
+      this.customLogger.info(`Converted fluctuation data: ${JSON.stringify(save)}`, this.context);
+
       await this.saveFluctuationRankStocks(save, this.datasource.manager);
 
       save.forEach((data) => {
@@ -56,6 +63,7 @@ export class OpenapiFluctuationData {
   }
 
   private convertToFluctuationRankStock(data: Json, isRising: boolean) {
+    this.customLogger.info(`Convert OpenAPI data to fluctuation rank stocks`, this.context);
     if (!Array.isArray(data.output))
       return [
         {
@@ -72,6 +80,7 @@ export class OpenapiFluctuationData {
   }
 
   private insertLiveDataRequest(stockId: string) {
+    this.customLogger.info(`Enqueue live data request for stock: ${stockId}`, this.context);
     this.openApiQueue.enqueue({
       url: this.liveUrl,
       query: {
@@ -87,6 +96,7 @@ export class OpenapiFluctuationData {
     result: Omit<FluctuationRankStock, 'id' | 'createdAt'>[],
     manager: EntityManager,
   ) {
+    this.customLogger.info(`Save fluctuation rank stocks to DB`, this.context);
     await manager
       .getRepository(FluctuationRankStock)
       .createQueryBuilder()

--- a/packages/backend/src/scraper/openapi/api/openapiRankView.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiRankView.api.ts
@@ -21,6 +21,8 @@ export class OpenapiRankViewApi {
     setTimeout(() => this.getTopViewsStockLiveData(), 6000);
   }
 
+  // TODO: 현재 조회수 상위 10개 종목을 1분마다 openAPI로 요청하고 있는데,
+  // 현재는 조회수 상위 10개를 보여주고 있지 않기 때문에 삭제하거나 "시가총액" 상위 10개 종목으로 변경해야 함
   @Cron('*/1 9-15 * * 1-5')
   async getTopViewsStockLiveData() {
     this.customLogger.info('Enqueue getTopViewsStockLiveData requests', this.context);

--- a/packages/backend/src/scraper/openapi/api/openapiRankView.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiRankView.api.ts
@@ -5,21 +5,25 @@ import { OpenapiLiveData } from '@/scraper/openapi/api/openapiLiveData.api';
 import { OpenapiQueue } from '@/scraper/openapi/queue/openapi.queue';
 import { TR_IDS } from '@/scraper/openapi/type/openapiUtil.type';
 import { Stock } from '@/stock/domain/stock.entity';
+import { CustomLogger } from '@/common/logger/customLogger';
 
 @Injectable()
 export class OpenapiRankViewApi {
   private readonly liveUrl = '/uapi/domestic-stock/v1/quotations/inquire-price';
+  private readonly context = 'OpenapiRankViewApi';
 
   constructor(
     private readonly datasource: DataSource,
     private readonly openApiLiveData: OpenapiLiveData,
     private readonly openApiQueue: OpenapiQueue,
+    private readonly customLogger: CustomLogger,
   ) {
     setTimeout(() => this.getTopViewsStockLiveData(), 6000);
   }
 
   @Cron('*/1 9-15 * * 1-5')
   async getTopViewsStockLiveData() {
+    this.customLogger.info('Enqueue getTopViewsStockLiveData requests', this.context);
     const date = await this.findTopViewsStocks();
     date.forEach((stock) => {
       this.openApiQueue.enqueue({
@@ -35,6 +39,7 @@ export class OpenapiRankViewApi {
   }
 
   private async findTopViewsStocks() {
+    this.customLogger.info('Find top views stocks from DB', this.context);
     return await this.datasource.manager
       .getRepository(Stock)
       .createQueryBuilder('stock')

--- a/packages/backend/src/scraper/openapi/api/openapiToken.api.ts
+++ b/packages/backend/src/scraper/openapi/api/openapiToken.api.ts
@@ -43,7 +43,6 @@ export class OpenapiTokenApi {
 
   @Cron('30 0 * * *')
   async init() {
-    this.customLogger.info('Initialize OpenAPI token', this.context);
     const expired_config = this.config.filter(
       (val) =>
         this.isTokenExpired(val.STOCK_API_TIMEOUT) &&
@@ -51,6 +50,8 @@ export class OpenapiTokenApi {
     );
     const isUndefined = this.config[0].STOCK_WEBSOCKET_TIMEOUT ? false : true;
     if (!isUndefined && !expired_config.length) return;
+
+    this.customLogger.info('Initialize OpenAPI token', this.context);
     const tokens = this.convertConfigToTokenEntity(this.config);
     const config = await this.getPropertyFromDB(tokens);
     const expired = config.filter(

--- a/packages/backend/src/scraper/openapi/queue/openapi.queue.ts
+++ b/packages/backend/src/scraper/openapi/queue/openapi.queue.ts
@@ -24,6 +24,7 @@ export class OpenapiQueue {
   private queue: PriorityQueue<OpenapiQueueNodeValue> = new PriorityQueue();
   constructor() {}
 
+  // TODO: value.count의 기본값이 5인 상태인데, 현재 등록된 API KEY가 1개이기 때문에 문제가 발생할 수 있음
   enqueue(value: OpenapiQueueNodeValue, priority?: number) {
     if (!priority) priority = 2;
     if (value.count === undefined) value.count = 5;
@@ -110,7 +111,7 @@ export class OpenapiConsumer {
       }
       this.customLogger.warn(`OpenAPI queue warning - URL:${node.url}, trId: ${node.trId}`, error, this.context);
       this.customLogger.warn('Warning details', error, this.context);
-      this.customLogger.warn(`Retries left: ${node.count}`, this.context);
+      this.customLogger.warn(`Retries left: ${node.count - 1}`, this.context);
       node.count -= 1;
       this.queue.enqueue(node, 1);
     }

--- a/packages/backend/src/scraper/scraper.module.ts
+++ b/packages/backend/src/scraper/scraper.module.ts
@@ -6,6 +6,6 @@ import { OpenapiScraperModule } from './openapi/openapi-scraper.module';
   imports: [KoreaStockInfoModule, OpenapiScraperModule],
   controllers: [],
   providers: [],
-  exports: [OpenapiScraperModule],
+  exports: [],
 })
 export class ScraperModule {}


### PR DESCRIPTION
- ready for deploy test #24

## ✅ 작업 내용

### 커스텀 로거

- scraper 디렉토리 밑에 있는 클래스들에 커스텀 로깅을 적용했습니다.
    - 특히 openApi websocket으로 enqueue 하는 경우와 DB에게 요청하는 경우에 대한 로깅에 신경썼습니다.
- 커스텀 로거의 상세 구현 로직을 조금 수정했습니다.
    -  warn() 메서드에서도 Error 객체를 인자를 받을 수 있도록 수정
    - log() 메서드 내부적으로 message에 대한 검사를 우선으로 하고, 이후 errorOrContext 검사

### 사소한 수정

- Injectable() 데코레이터가 누락되어 있던 openapiIndex 클래스에 데코레이터를 추가했습니다. 
- openApi와 관련된 코드들 중 문제가 될 수 있거나 개선이 필요할 법한 부분에 TODO 주석을 추가했습니다.

### pool 커넥션 최대 개수 제한 변경

- 기존에 default값이었던 10개에서 30개로 수정했습니다.
- 이 수정만으로 문제가 해결된다는 보장은 없지만, 안정성이 조금은 올라갈 것 같습니다.

## [개발일지](https://www.notion.so/25-02-17-25-02-18-19d391ecf7be80d0b64ad74fb3b9a29f)

## 📸 스크린샷(FE만)

## 📌 이슈 사항

- 배포환경에 팀원 모두의 openAPI key를 등록하는 것이 좋아 보입니다.

## 🟢 완료 조건

## ✍ 궁금한 점

## 😎 체크 사항

- [x] label 설정 확인
- [x] 브랜치 방향 확인
